### PR TITLE
Ensure there is no diff for changes is in non-yor tags

### DIFF
--- a/common/structure/block.go
+++ b/common/structure/block.go
@@ -50,37 +50,18 @@ func (b *Block) AddNewTags(newTags []tags.ITag) {
 	b.NewTags = append(b.NewTags, newTags...)
 }
 
-// MergeTags merges the tags while trying to preserve the existing order of the tags.
-// It does this by first iterating through the existing tags and updating the values if there's anything to update.
-// Then it adds all the new tags that didn't exist beforehand.
+// MergeTags merges the tags and returns only the relevant Yor tags.
 func (b *Block) MergeTags() []tags.ITag {
 	var mergedTags []tags.ITag
 
-	for _, existingTag := range b.GetExistingTags() {
-		found := false
-		for _, newTag := range b.GetNewTags() {
-			if newTag.GetKey() == existingTag.GetKey() {
-				mergedTags = append(mergedTags, newTag)
-				found = true
-				break
-			}
-		}
-		if !found {
-			mergedTags = append(mergedTags, existingTag)
+	for _, tag := range b.ExitingTags {
+		if val, ok := tag.(*tags.YorTraceTag); ok {
+			mergedTags = append(mergedTags, val)
 		}
 	}
-	for _, newTag := range b.GetNewTags() {
-		var found bool
-		for _, updateTag := range mergedTags {
-			if updateTag.GetKey() == newTag.GetKey() {
-				found = true
-				break
-			}
-		}
-		if !found {
-			mergedTags = append(mergedTags, newTag)
-		}
-	}
+
+	mergedTags = append(mergedTags, b.NewTags...)
+
 	return mergedTags
 }
 

--- a/tests/terraform/structure/terraform_block_test.go
+++ b/tests/terraform/structure/terraform_block_test.go
@@ -38,6 +38,12 @@ func TestTerrraformBlock(t *testing.T) {
 					Value: "terragoat",
 				},
 			},
+			&tags.GitOrgTag{
+				Tag: tags.Tag{
+					Key:   "git_org",
+					Value: "bridgecrewio",
+				},
+			},
 		}
 		block := structure.TerraformBlock{
 			Block: structure2.Block{
@@ -123,7 +129,7 @@ func TestTerrraformBlock(t *testing.T) {
 		diff := block.CalculateTagsDiff()
 		merged := block.MergeTags()
 
-		assert.Equal(t, 4, len(merged), "Merging failed, expected to see 3 tags")
+		assert.Equal(t, 3, len(merged), "Merging failed, expected to see 3 tags")
 		assert.Equal(t, 0, len(diff["updated"]))
 		assert.Equal(t, 0, len(diff["added"]))
 	})


### PR DESCRIPTION
The algorithm today searches for changes only in yor tags, so it was already almost-good. 
Moved the `found` variable to ensure tags which haven't changed are not marked as new.