### PR TITLE
Identify remote modules correctly & avoid failures between releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -173,7 +173,7 @@ jobs:
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT }}
   update-bridgecrew-projects:
-    needs: create-release
+    needs: publish-dockerhub
     runs-on: ubuntu-latest
     steps:
       - name: update on yor release

--- a/src/terraform/structure/terraform_module_test.go
+++ b/src/terraform/structure/terraform_module_test.go
@@ -1,0 +1,37 @@
+package structure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerrraformModule(t *testing.T) {
+	t.Run("Test TF Module remote https logic", func(t *testing.T) {
+		isRemote := isRemoteModule("https://github.com/terraform-aws-modules/terraform-aws-vpc.git")
+		assert.True(t, isRemote)
+	})
+
+	t.Run("Test TF Module remote github logic", func(t *testing.T) {
+		isRemote := isRemoteModule("github.com/terraform-aws-modules/terraform-aws-vpc.git")
+		assert.True(t, isRemote)
+	})
+
+	t.Run("Test TF Module remote git logic", func(t *testing.T) {
+		isRemote := isRemoteModule("git@github.com:terraform-aws-modules/terraform-aws-vpc.git")
+		assert.True(t, isRemote)
+	})
+
+	t.Run("Test TF Module local logic", func(t *testing.T) {
+		localPath := "test/local/path"
+		isRemote := isRemoteModule(localPath)
+		assert.False(t, isRemote)
+		isRegistry := isTerraformRegistryModule(localPath)
+		assert.False(t, isRegistry)
+	})
+
+	t.Run("Test TF Registry Module logic", func(t *testing.T) {
+		isRegistry := isTerraformRegistryModule("terraform-aws-modules/security-group/aws")
+		assert.True(t, isRegistry)
+	})
+}


### PR DESCRIPTION
Resolves #90 

Also avoids updating the action before the dockerhub image is updated to avoid:
```
Step 1/5 : FROM bridgecrew/yor:0.1.27
  manifest for bridgecrew/yor:0.1.27 not found: manifest unknown: manifest unknown
Error: Docker build failed with exit code 1
```