### PR TITLE
Tag modules which already have the tags attribute

### DIFF
--- a/src/terraform/structure/terraform_block.go
+++ b/src/terraform/structure/terraform_block.go
@@ -13,6 +13,12 @@ type TerraformBlock struct {
 	HclSyntaxBlock *hclsyntax.Block
 }
 
+const ResourceBlockType = "resource"
+const ModuleBlockType = "module"
+const DataBlockType = "data"
+
+var SupportedBlockTypes = []string{ResourceBlockType, ModuleBlockType}
+
 func (b *TerraformBlock) GetResourceID() string {
 	return strings.Join(b.HclSyntaxBlock.Labels, ".")
 }

--- a/tests/terraform/module/module_with_tags/expected.txt
+++ b/tests/terraform/module/module_with_tags/expected.txt
@@ -7,6 +7,8 @@ module "complete_sg" {
   ingress_rules       = ["https-443-tcp"]
 
   tags = {
-    Name = "test-sg"
+    Name      = "test-sg"
+    mock_tag  = "mock_value"
+    yor_trace = "some-uuid"
   }
 }

--- a/tests/terraform/module/module_with_tags/main.tf
+++ b/tests/terraform/module/module_with_tags/main.tf
@@ -1,0 +1,16 @@
+module "complete_sg" {
+  source              = "terraform-aws-modules/security-group/aws"
+  name                = "my-sg-test"
+  vpc_id              = "some-vpc-id"
+  use_name_prefix     = true
+  ingress_cidr_blocks = ["10.10.0.0/16"]
+  ingress_rules       = ["https-443-tcp"]
+
+  tags = {
+    Name = "test-sg"
+  }
+   = {
+    Name      = "test-sg"
+    yor_trace = "955a885c-9292-4288-bebb-ccbf5e613ef4"
+  }
+}


### PR DESCRIPTION
Add modules as supported block types and implement tag enrichment.

To be implemented: if the module doesn't have the tags attribute in use, look up the module and find if it supports tags