### PR TITLE
Support deeper Gitlab endpoint paths

### DIFF
--- a/src/common/gitservice/git_service.go
+++ b/src/common/gitservice/git_service.go
@@ -75,11 +75,11 @@ func (g *GitService) setOrgAndName() error {
 			}
 			// remove leading '/' from path and trailing '.git. suffix, then split by '/'
 			endpointPathParts := strings.Split(strings.TrimSuffix(strings.TrimLeft(endpoint.Path, "/"), ".git"), "/")
-			if len(endpointPathParts) != 2 {
+			if len(endpointPathParts) < 2 {
 				return fmt.Errorf("invalid format of endpoint path: %s", endpoint.Path)
 			}
 			g.organization = endpointPathParts[0]
-			g.repoName = endpointPathParts[1]
+			g.repoName = strings.Join(endpointPathParts[1:], "/")
 			break
 		}
 	}

--- a/src/common/gitservice/git_service_test.go
+++ b/src/common/gitservice/git_service_test.go
@@ -35,6 +35,17 @@ func TestNewGitService(t *testing.T) {
 		assert.Equal(t, "terragoat", gitService.GetRepoName())
 	})
 
+	t.Run("Get correct organization and repo name from deeper gitlab", func(t *testing.T) {
+		gitlabPath := utils.CloneRepo("https://gitlab.com/gitlab-org/configure/examples/gitlab-terraform-aws.git", "4e45d0983ec157376b3389f08e565acdc6f49eee")
+		defer os.RemoveAll(gitlabPath)
+		gitService, err := NewGitService(gitlabPath)
+		if err != nil {
+			t.Errorf("could not initialize git service becauses %s", err)
+		}
+		assert.Equal(t, "gitlab-org", gitService.GetOrganization())
+		assert.Equal(t, "configure/examples/gitlab-terraform-aws", gitService.GetRepoName())
+	})
+
 	t.Run("Fail if gotten to root dir", func(t *testing.T) {
 		terragoatPath := utils.CloneRepo(utils.TerragoatURL, "063dc2db3bb036160ed39d3705508ee8293a27c8")
 		defer os.RemoveAll(terragoatPath)

--- a/src/common/tagging/gittag/git_tag_group.go
+++ b/src/common/tagging/gittag/git_tag_group.go
@@ -34,7 +34,7 @@ func (t *TagGroup) InitTagGroup(path string, skippedTags []string) {
 	if path != "" {
 		gitService, err := gitservice.NewGitService(path)
 		if err != nil {
-			logger.Error(fmt.Sprintf("Failed to initialize git service for path %s. Please ensure the provided root directory is initialized via the git init command.", path), "SILENT")
+			logger.Error(fmt.Sprintf("Failed to initialize git service for path \"%s\". Please ensure the provided root directory is initialized via the git init command: %q", path, err), "SILENT")
 		}
 		t.GitService = gitService
 	} else {


### PR DESCRIPTION
Deep Gitlab endpoint paths with more than two slashes are not supported:

```
# yor tag -d .
2021/05/28 15:06:54 [ERROR] Failed to initialize git service for path ".". Please ensure the provided root directory is initialized via the git init command: "invalid format of endpoint path: configure/examples/gitlab-terraform-aws.git"
```
