### PR TITLE
Don't tag local module as the resources will be tagged

### DIFF
--- a/src/terraform/structure/terraform_module.go
+++ b/src/terraform/structure/terraform_module.go
@@ -91,13 +91,15 @@ func (t *TerraformModule) GetModulesDirectories() []string {
 	modulesDirectories := []string{t.rootDir}
 
 	for _, moduleCall := range t.tfModule.ModuleCalls {
-		childModuleDir := path.Join(t.rootDir, moduleCall.Source)
-		childModule := NewTerraformModule(childModuleDir)
-		childModulesDirectories := childModule.GetModulesDirectories()
-		for _, childDirPath := range childModulesDirectories {
-			if _, err := os.Stat(childDirPath); !os.IsNotExist(err) && !utils.InSlice(modulesDirectories, childDirPath) {
-				// if directory exists (local module) and modulesDirectories doesn't contain it yet, add it
-				modulesDirectories = append(modulesDirectories, childDirPath)
+		if !isRemoteModule(moduleCall.Source) && !isTerraformRegistryModule(moduleCall.Source) {
+			childModuleDir := path.Join(t.rootDir, moduleCall.Source)
+			childModule := NewTerraformModule(childModuleDir)
+			childModulesDirectories := childModule.GetModulesDirectories()
+			for _, childDirPath := range childModulesDirectories {
+				if _, err := os.Stat(childDirPath); !os.IsNotExist(err) && !utils.InSlice(modulesDirectories, childDirPath) {
+					// if directory exists (local module) and modulesDirectories doesn't contain it yet, add it
+					modulesDirectories = append(modulesDirectories, childDirPath)
+				}
 			}
 		}
 	}

--- a/tests/terraform/resources/local_module/main.tf
+++ b/tests/terraform/resources/local_module/main.tf
@@ -1,0 +1,6 @@
+module "sub_module" {
+  source =   "./sub_local_module"
+  tags = {
+    Name = "test"
+  }
+}

--- a/tests/terraform/resources/local_module/sub_local_module/main.tf
+++ b/tests/terraform/resources/local_module/sub_local_module/main.tf
@@ -1,0 +1,17 @@
+resource "aws_vpc" "tagged_vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = merge(var.tags, {
+    yor_trace = "3b06a351-83d4-4922-90b3-a4a35bab9bb7"
+  })
+}
+
+resource "aws_s3_bucket" "my-bucket" {
+  bucket = "my-bucket"
+  tags = {
+    yor_trace = "99205876-f974-4075-b032-12fac6bfa938"
+  }
+}
+
+module "sg" {
+  source = "terraform-aws-modules/vpc/aws"
+}

--- a/tests/terraform/resources/local_module/sub_local_module/variables.tf
+++ b/tests/terraform/resources/local_module/sub_local_module/variables.tf
@@ -1,0 +1,3 @@
+variable "tags" {
+  type = map(string)
+}


### PR DESCRIPTION
This is to avoid the case where module-level tags overwrite the resource level tags