### PR TITLE
GCP labels - clean git_repo

### DIFF
--- a/src/common/tagging/gittag/git_repo.go
+++ b/src/common/tagging/gittag/git_repo.go
@@ -13,7 +13,7 @@ type GitRepoTag struct {
 }
 
 func (t *GitRepoTag) Init() {
-	t.Key = "git_repo"
+	t.Key = gitRepoTagKey
 }
 
 func (t *GitRepoTag) CalculateValue(data interface{}) (tags.ITag, error) {

--- a/src/common/tagging/gittag/git_tag_group.go
+++ b/src/common/tagging/gittag/git_tag_group.go
@@ -34,6 +34,7 @@ const gitModifiersTagKey = "git_modifiers"
 const gitLastModifiedAtTagKey = "git_last_modified_at"
 const gitLastModifiedByTagKey = "git_last_modified_by"
 const gitFileTagKey = "git_file"
+const gitRepoTagKey = "git_repo"
 
 func (t *TagGroup) InitTagGroup(path string, skippedTags []string) {
 	t.SkippedTags = skippedTags
@@ -232,6 +233,9 @@ func (t *TagGroup) cleanGCPTagValue(val tags.ITag) {
 	case gitLastModifiedByTagKey:
 		updated = strings.Split(updated, "@")[0]
 		updated = utils.RemoveGcpInvalidChars.ReplaceAllString(updated, "")
+	case gitRepoTagKey:
+		updated = strings.ReplaceAll(updated, "/", "__")
+		updated = strings.ReplaceAll(updated, ".", "_")
 	}
 
 	val.SetValue(updated)

--- a/src/common/tagging/gittag/git_tag_group_test.go
+++ b/src/common/tagging/gittag/git_tag_group_test.go
@@ -71,6 +71,7 @@ func TestGittagGroup_mapOriginFileToGitFile(t *testing.T) {
 			&tags.Tag{Key: gitModifiersTagKey, Value: "bana/shati"},
 			&tags.Tag{Key: gitLastModifiedAtTagKey, Value: "2021-06-02 07:53:27"},
 			&tags.Tag{Key: gitLastModifiedByTagKey, Value: "gandalf@bridgecrew.io"},
+			&tags.Tag{Key: gitRepoTagKey, Value: "path/to/repo.git"},
 		}
 		for _, tag := range tagsList {
 			gittagGroup.cleanGCPTagValue(tag)


### PR DESCRIPTION
Git repository paths may contain directories and subdirectories, so the `git_repo` tag must also be modified to match Google's regex limitations, eg:

```
Error: Error updating Secret "projects/project/secrets/thing": googleapi: Error 400: Invalid field "labels.git_repo"; value "foo/bar" does not conform to regular expression "[\p{Ll}\p{Lo}\p{N}_-]{0,63}"; character "/" at position 4 is not a non-uppercased letter (Unicode character class Ll or Lo), digit, hyphen, or underscore
```

This PR naiively builds on the structure of @nimrodkor previous MR.  Mostly untested - I'm not a Go developer - but this might work :D