### PR TITLE
Allow external tag group to handle modifiers tag as list

### DIFF
--- a/src/common/tagging/gittag/git_file.go
+++ b/src/common/tagging/gittag/git_file.go
@@ -13,7 +13,7 @@ type GitFileTag struct {
 }
 
 func (t *GitFileTag) Init() {
-	t.Key = gitFileTagKey
+	t.Key = tags.GitFileTagKey
 }
 
 func (t *GitFileTag) CalculateValue(data interface{}) (tags.ITag, error) {

--- a/src/common/tagging/gittag/git_last_modified_at.go
+++ b/src/common/tagging/gittag/git_last_modified_at.go
@@ -13,7 +13,7 @@ type GitLastModifiedAtTag struct {
 }
 
 func (t *GitLastModifiedAtTag) Init() {
-	t.Key = gitLastModifiedAtTagKey
+	t.Key = tags.GitLastModifiedAtTagKey
 }
 
 func (t *GitLastModifiedAtTag) CalculateValue(data interface{}) (tags.ITag, error) {

--- a/src/common/tagging/gittag/git_last_modified_by.go
+++ b/src/common/tagging/gittag/git_last_modified_by.go
@@ -13,7 +13,7 @@ type GitLastModifiedByTag struct {
 }
 
 func (t *GitLastModifiedByTag) Init() {
-	t.Key = gitLastModifiedByTagKey
+	t.Key = tags.GitLastModifiedByTagKey
 }
 
 func (t *GitLastModifiedByTag) CalculateValue(data interface{}) (tags.ITag, error) {

--- a/src/common/tagging/gittag/git_modifiers.go
+++ b/src/common/tagging/gittag/git_modifiers.go
@@ -15,7 +15,7 @@ type GitModifiersTag struct {
 }
 
 func (t *GitModifiersTag) Init() {
-	t.Key = gitModifiersTagKey
+	t.Key = tags.GitModifiersTagKey
 }
 
 func (t *GitModifiersTag) CalculateValue(data interface{}) (tags.ITag, error) {

--- a/src/common/tagging/gittag/git_repo.go
+++ b/src/common/tagging/gittag/git_repo.go
@@ -13,7 +13,7 @@ type GitRepoTag struct {
 }
 
 func (t *GitRepoTag) Init() {
-	t.Key = gitRepoTagKey
+	t.Key = tags.GitRepoTagKey
 }
 
 func (t *GitRepoTag) CalculateValue(data interface{}) (tags.ITag, error) {

--- a/src/common/tagging/gittag/git_tag_group.go
+++ b/src/common/tagging/gittag/git_tag_group.go
@@ -30,12 +30,6 @@ type fileLineMapper struct {
 	gitToOrigin map[int]int
 }
 
-const gitModifiersTagKey = "git_modifiers"
-const gitLastModifiedAtTagKey = "git_last_modified_at"
-const gitLastModifiedByTagKey = "git_last_modified_by"
-const gitFileTagKey = "git_file"
-const gitRepoTagKey = "git_repo"
-
 func (t *TagGroup) InitTagGroup(path string, skippedTags []string) {
 	t.SkippedTags = skippedTags
 	if path != "" {
@@ -218,22 +212,22 @@ func (t *TagGroup) hasNonTagChanges(blame *gitservice.GitBlame, block structure.
 func (t *TagGroup) cleanGCPTagValue(val tags.ITag) {
 	updated := val.GetValue()
 	switch val.GetKey() {
-	case gitModifiersTagKey:
+	case tags.GitModifiersTagKey:
 		modifiers := strings.Split(updated, "/")
 		for i, m := range modifiers {
 			modifiers[i] = utils.RemoveGcpInvalidChars.ReplaceAllString(m, "")
 		}
 		updated = strings.Join(modifiers, "__")
-	case gitLastModifiedAtTagKey:
+	case tags.GitLastModifiedAtTagKey:
 		updated = strings.ReplaceAll(updated, " ", "-")
 		updated = strings.ReplaceAll(updated, ":", "-")
-	case gitFileTagKey:
+	case tags.GitFileTagKey:
 		updated = strings.ReplaceAll(updated, "/", "__")
 		updated = strings.ReplaceAll(updated, ".", "_")
-	case gitLastModifiedByTagKey:
+	case tags.GitLastModifiedByTagKey:
 		updated = strings.Split(updated, "@")[0]
 		updated = utils.RemoveGcpInvalidChars.ReplaceAllString(updated, "")
-	case gitRepoTagKey:
+	case tags.GitRepoTagKey:
 		updated = strings.ReplaceAll(updated, "/", "__")
 		updated = strings.ReplaceAll(updated, ".", "_")
 	}

--- a/src/common/tagging/gittag/git_tag_group_test.go
+++ b/src/common/tagging/gittag/git_tag_group_test.go
@@ -68,11 +68,11 @@ func TestGittagGroup_mapOriginFileToGitFile(t *testing.T) {
 	t.Run("test_gcp_tag_cleansing", func(t *testing.T) {
 		gittagGroup := TagGroup{}
 		tagsList := []tags.ITag{
-			&tags.Tag{Key: gitFileTagKey, Value: "test/to/path.tf"},
-			&tags.Tag{Key: gitModifiersTagKey, Value: "bana/shati"},
-			&tags.Tag{Key: gitLastModifiedAtTagKey, Value: "2021-06-02 07:53:27"},
-			&tags.Tag{Key: gitLastModifiedByTagKey, Value: "gandalf@bridgecrew.io"},
-			&tags.Tag{Key: gitRepoTagKey, Value: "path/to/repo.git"},
+			&tags.Tag{Key: tags.GitFileTagKey, Value: "test/to/path.tf"},
+			&tags.Tag{Key: tags.GitModifiersTagKey, Value: "bana/shati"},
+			&tags.Tag{Key: tags.GitLastModifiedAtTagKey, Value: "2021-06-02 07:53:27"},
+			&tags.Tag{Key: tags.GitLastModifiedByTagKey, Value: "gandalf@bridgecrew.io"},
+			&tags.Tag{Key: tags.GitRepoTagKey, Value: "path/to/repo.git"},
 		}
 		for _, tag := range tagsList {
 			gittagGroup.cleanGCPTagValue(tag)

--- a/src/common/tagging/tags/tag.go
+++ b/src/common/tagging/tags/tag.go
@@ -11,6 +11,11 @@ type Tag struct {
 }
 
 const YorTraceTagKey = "yor_trace"
+const GitFileTagKey = "git_file"
+const GitModifiersTagKey = "git_modifiers"
+const GitLastModifiedAtTagKey = "git_last_modified_at"
+const GitLastModifiedByTagKey = "git_last_modified_by"
+const GitRepoTagKey = "git_repo"
 
 type ITag interface {
 	Init()

--- a/src/serverless/structure/serverless_parser.go
+++ b/src/serverless/structure/serverless_parser.go
@@ -68,9 +68,11 @@ func (p *ServerlessParser) ParseFile(filePath string) ([]structure.IBlock, error
 	template, err := goserverlessParse(filePath)
 	p.Template = template
 	if err != nil || template == nil || template.Functions == nil {
-		logger.Warning(fmt.Sprintf("There was an error processing the serverless template: %s", err))
+		if err != nil {
+			logger.Warning(fmt.Sprintf("There was an error processing the serverless template: %s", err))
+		}
 		if err == nil {
-			err = fmt.Errorf("failed to parse file")
+			err = fmt.Errorf("failed to parse file %v", filePath)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Git modifiers tag is a list of users, separated by `/`.
To allow building custom tags on top of it, we need to be able to iterate through this list.

Also 3 minor fixes:
1. Cast MatchesConfig to `map[string]interface{}`
2. Move git tag names to common file so other parts of `yor` can access it (external_tag_group is one)
3. Fix serverless logging in case of error
