### PR TITLE
Skip AWS autoscaling group tags as they are of a different structure

### DIFF
--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -505,6 +505,11 @@ func (p *TerrraformParser) getExistingTags(hclBlock *hclwrite.Block, tagsAttribu
 
 func (p *TerrraformParser) isBlockTaggable(hclBlock *hclwrite.Block) (bool, error) {
 	resourceType := hclBlock.Labels()[0]
+	if resourceType == "aws_autoscaling_group" {
+		// This resource specifically supports tags with a different structure, see:
+		// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#tag-and-tags
+		return false, nil
+	}
 	if val, ok := p.taggableResourcesCache[resourceType]; ok {
 		return val, nil
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
