### PR TITLE
Support more possible module tag attributes

### DIFF
--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -158,3 +158,18 @@ func SplitStringByComma(input []string) []string {
 	}
 	return ans
 }
+
+func FindSubMatchByGroup(r *regexp.Regexp, str string) map[string]string {
+	match := r.FindStringSubmatch(str)
+	if match == nil {
+		return nil
+	}
+	subMatchMap := make(map[string]string)
+	for i, name := range r.SubexpNames() {
+		if i != 0 {
+			subMatchMap[name] = match[i]
+		}
+	}
+
+	return subMatchMap
+}

--- a/src/terraform/structure/terraform_module.go
+++ b/src/terraform/structure/terraform_module.go
@@ -171,9 +171,11 @@ func isRemoteModule(s string) bool {
 func isTerraformRegistryModule(source string) bool {
 	// All terraform registry modules are of the following structure:
 	// terraform-<PROVIDER>-modules/<MODULE_NAME>/<PROVIDER>
-	parts := strings.Split(source, "/")
+	// OR
+	// oracle-terraform-modules/<MODULE_NAME>/<PROVIDER>
+	parts := strings.Split(strings.Split(source, "//")[0], "/")
 	if len(parts) == 3 {
-		if "terraform-"+parts[2]+"-modules" == parts[0] {
+		if _, ok := ProviderToTagAttribute[parts[2]]; "terraform-"+parts[2]+"-modules" == parts[0] || ok {
 			return true
 		}
 	}

--- a/src/terraform/structure/terraform_module_test.go
+++ b/src/terraform/structure/terraform_module_test.go
@@ -49,6 +49,11 @@ func TestTerrraformModule(t *testing.T) {
 		assert.True(t, isRegistry)
 	})
 
+	t.Run("Test TF registry with inner path", func(t *testing.T) {
+		isRegistry := isTerraformRegistryModule("claranet/run-common/azurerm//modules/logs")
+		assert.True(t, isRegistry)
+	})
+
 	t.Run("Handle unsupported providers gracefully", func(t *testing.T) {
 		currentDir, _ := os.Getwd()
 		providersDir, _ := filepath.Abs(currentDir + "../../../../tests/terraform/providers")

--- a/src/terraform/structure/terraform_module_test.go
+++ b/src/terraform/structure/terraform_module_test.go
@@ -34,13 +34,18 @@ func TestTerrraformModule(t *testing.T) {
 	})
 
 	t.Run("Test TF Module private registry", func(t *testing.T) {
-		path := "app.terraform.io/path/to/module/aws"
+		path := "app.terraform.io/acme/rds/aws"
 		isRemote := isRemoteModule(path)
 		assert.True(t, isRemote)
 	})
 
 	t.Run("Test TF Registry Module logic", func(t *testing.T) {
 		isRegistry := isTerraformRegistryModule("terraform-aws-modules/security-group/aws")
+		assert.True(t, isRegistry)
+	})
+
+	t.Run("Test TF Registry Module OCI logic", func(t *testing.T) {
+		isRegistry := isTerraformRegistryModule("oracle-terraform-modules/bastion/oci")
 		assert.True(t, isRegistry)
 	})
 

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -429,11 +429,9 @@ func ExtractProviderFromModuleSrc(source string) string {
 		// https://www.terraform.io/docs/cloud/registry/using.html
 		return strings.Split(withoutRef, "/")[3]
 	}
-	registryParts := strings.Split(withoutRef, "/")
-	if len(registryParts) == 3 {
-		if _, ok := ProviderToTagAttribute[registryParts[2]]; ok {
-			return registryParts[2]
-		}
+	if isTerraformRegistryModule(source) {
+		// Terraform modules in public registry follow this structure: <PREFIX>/<MODULE NAME>/<PROVIDER>
+		return strings.Split(withoutRef, "/")[2]
 	}
 	parts := strings.Split(strings.TrimRight(withoutRef, ".git"), "/")
 	for _, part := range parts {

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -423,16 +423,17 @@ func (p *TerrraformParser) parseBlock(hclBlock *hclwrite.Block, filePath string)
 }
 
 func ExtractProviderFromModuleSrc(source string) string {
-	withoutRef := strings.Split(source, "//")[0]
-	if strings.HasPrefix(withoutRef, "app.terraform.io") {
+	if strings.HasPrefix(source, "app.terraform.io") {
 		// Terraform modules in private registry follow this structure: <HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>
 		// https://www.terraform.io/docs/cloud/registry/using.html
-		return strings.Split(withoutRef, "/")[3]
+		return strings.Split(source, "/")[3]
 	}
 	if isTerraformRegistryModule(source) {
-		// Terraform modules in public registry follow this structure: <PREFIX>/<MODULE NAME>/<PROVIDER>
-		return strings.Split(withoutRef, "/")[2]
+		matches := utils.FindSubMatchByGroup(RegistryModuleRegex, source)
+		val, _ := matches["PROVIDER"]
+		return val
 	}
+	withoutRef := strings.Split(source, "//")[0]
 	parts := strings.Split(strings.TrimRight(withoutRef, ".git"), "/")
 	for _, part := range parts {
 		if strings.HasPrefix(part, "terraform-") {

--- a/tests/terraform/module/provider_modules/main.tf
+++ b/tests/terraform/module/provider_modules/main.tf
@@ -1,0 +1,59 @@
+module "project-factory" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "11.0.0"
+  labels  = {
+    test = "true"
+  }
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.2.0"
+  tags    = {
+    test = "true"
+  }
+}
+
+module "project-factory_github" {
+  source = "github.com/terraform-google-modules/terraform-google-project-factory"
+  labels = {
+    test = "true"
+  }
+}
+
+module "project-factory_git" {
+  source = "git@github.com:terraform-google-modules/terraform-google-project-factory.git"
+  labels = {
+    test = "true"
+  }
+}
+
+module "caf" {
+  source = "aztfmod/caf/azurerm"
+  tags   = {
+    test = "true"
+  }
+}
+
+module "caf" {
+  source = "git@github.com:aztfmod/terraform-azurerm-caf.git"
+  tags   = {
+    test = "true"
+  }
+}
+
+module "bastion" {
+  source        = "oracle-terraform-modules/bastion/oci"
+  freeform_tags = {
+    test = "true"
+  }
+}
+
+module "run-common_logs" {
+  // Tags attribute is extra_tags
+  source  = "claranet/run-common/azurerm//modules/logs"
+  version = "3.0.0"
+  extra_tags = {
+    test = "true"
+  }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Support the keywords `tags` & `extra_tags` for all providers + the provider-related keywords. Cases that led me to this:
1. A lot of OCI modules, which uses `freeform_tags`, use var named `tags`.
2. A lot of Azure & AWS modules use `extra_tags` instead of `tags`