### PR TITLE
Don't crash on malformed CloudFormation templates 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 *.so
 .gobuild
 dist/
-
-dist/
+/yor

--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -67,7 +67,7 @@ func (p *CloudformationParser) ParseFile(filePath string) ([]structure.IBlock, e
 	}
 
 	resourceNames := make([]string, 0)
-	if template.Resources != nil {
+	if template.Resources != nil && len(template.Resources) > 0 {
 		for resourceName := range template.Resources {
 			resourceNames = append(resourceNames, resourceName)
 		}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

YAML files with a top-level `resources` key that contains unexpected
values can crash Yor. Detect this by checking we actually found some
resources under it.

Fixes crashes like:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x47baf2f]

goroutine 488 [running]:
github.com/bridgecrewio/yor/src/common/yaml.MapResourcesLineYAML(0xc00058c820, 0x46, 0xc0004b5b98, 0x0, 0x0, 0x5dd5fac, 0x9, 0xc000097bc0)
	/Users/me/personal/yor/src/common/yaml/yaml_writer.go:319 +0x32f
github.com/bridgecrewio/yor/src/cloudformation/structure.(*CloudformationParser).ParseFile(0xc0003f5ff0, 0xc00058c820, 0x46, 0x1, 0x1, 0xc000750230, 0x4f, 0x0)
	/Users/me/personal/yor/src/cloudformation/structure/cloudformation_parser.go:79 +0xc99
github.com/bridgecrewio/yor/src/common/runner.(*Runner).TagFile(0xc000037d40, 0xc00058c820, 0x46, 0xc00037d000)
	/Users/me/personal/yor/src/common/runner/runner.go:110 +0x349
created by github.com/bridgecrewio/yor/src/common/runner.(*Runner).TagDirectory
	/Users/me/personal/yor/src/common/runner/runner.go:96 +0x136
```