### PR TITLE
Add IParser.ValidFile

### DIFF
--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -59,7 +59,7 @@ func (p *CloudformationParser) GetSupportedFileExtensions() []string {
 
 // Validate file has AWSTemplateFormatVersion
 func (p *CloudformationParser) ValidFile(filePath string) bool {
-	file, err := os.Open("users.json")
+	file, err := os.Open(filePath)
 	if err != nil {
 		logger.Warning(fmt.Sprintf("Error opening file %s, skipping: %v", filePath, err))
 		return false

--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -59,6 +59,7 @@ func (p *CloudformationParser) GetSupportedFileExtensions() []string {
 
 // Validate file has AWSTemplateFormatVersion
 func (p *CloudformationParser) ValidFile(filePath string) bool {
+	// #nosec G304
 	file, err := os.Open(filePath)
 	if err != nil {
 		logger.Warning(fmt.Sprintf("Error opening file %s, skipping: %v", filePath, err))

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -5,6 +5,7 @@ import "github.com/bridgecrewio/yor/src/common/structure"
 type IParser interface {
 	Init(rootDir string, args map[string]string)
 	Name() string
+	ValidFile(filePath string) bool
 	ParseFile(filePath string) ([]structure.IBlock, error)
 	WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error
 	GetSkippedDirs() []string

--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -232,5 +232,8 @@ func (r *Runner) isFileSkipped(p common.IParser, file string) bool {
 			return true
 		}
 	}
+	if !p.ValidFile(file) {
+		return true
+	}
 	return false
 }

--- a/src/serverless/structure/serverless_parser.go
+++ b/src/serverless/structure/serverless_parser.go
@@ -59,6 +59,10 @@ func goserverlessParse(file string) (*serverless.Template, error) {
 	return template, err
 }
 
+func (p *ServerlessParser) ValidFile(filePath string) bool {
+	return true
+}
+
 func (p *ServerlessParser) ParseFile(filePath string) ([]structure.IBlock, error) {
 	parsedBlocks := make([]structure.IBlock, 0)
 	fileFormat := utils.GetFileFormat(filePath)

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -100,6 +100,10 @@ func (p *TerrraformParser) GetSourceFiles(directory string) ([]string, error) {
 	return files, nil
 }
 
+func (p *TerrraformParser) ValidFile(filePath string) bool {
+	return true
+}
+
 func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error) {
 	// read file bytes
 	// #nosec G304


### PR DESCRIPTION
This function validates a proposed file is really interesting for the
parser. This allows logic more complex than checking file extension.

An initial implementation for CloudFormation templates is included,
validating they contain a top-level AWSTemplateFormatVersion key. This
will help silence log lines like the following:

[WARNING] There was an error processing the cloudformation template my-helm-template.yaml: failed to unmarshal YAML: error converting YAML to JSON: yaml: did not find expected node content

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


=== Edit:
Fixes #180 