### PR TITLE
Support skipping resource types

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func tagCommand() *cli.Command {
 	tagGroupArg := "tag-groups"
 	outputJSONFileArg := "output-json-file"
 	externalConfPath := "config-file"
+	skipResourceTypesArg := "skip-resource-types"
 	return &cli.Command{
 		Name:                   "tag",
 		Usage:                  "apply tagging across your directory",
@@ -94,15 +95,16 @@ func tagCommand() *cli.Command {
 		UseShortOptionHandling: true,
 		Action: func(c *cli.Context) error {
 			options := clioptions.TagOptions{
-				Directory:      c.String(directoryArg),
-				Tag:            c.StringSlice(tagArg),
-				SkipTags:       c.StringSlice(skipTagsArg),
-				CustomTagging:  c.StringSlice(customTaggingArg),
-				SkipDirs:       c.StringSlice(skipDirsArg),
-				Output:         c.String(outputArg),
-				OutputJSONFile: c.String(outputJSONFileArg),
-				TagGroups:      c.StringSlice(tagGroupArg),
-				ConfigFile:     c.String(externalConfPath),
+				Directory:         c.String(directoryArg),
+				Tag:               c.StringSlice(tagArg),
+				SkipTags:          c.StringSlice(skipTagsArg),
+				CustomTagging:     c.StringSlice(customTaggingArg),
+				SkipDirs:          c.StringSlice(skipDirsArg),
+				Output:            c.String(outputArg),
+				OutputJSONFile:    c.String(outputJSONFileArg),
+				TagGroups:         c.StringSlice(tagGroupArg),
+				ConfigFile:        c.String(externalConfPath),
+				SkipResourceTypes: c.StringSlice(skipResourceTypesArg),
 			}
 
 			options.Validate()
@@ -167,6 +169,12 @@ func tagCommand() *cli.Command {
 				Name:        externalConfPath,
 				Usage:       "external tag group configuration file path",
 				DefaultText: "/path/to/conf/file/ (.yml/.yaml extension)",
+			},
+			&cli.StringSliceFlag{
+				Name:        skipResourceTypesArg,
+				Usage:       "skip resource types for tagging",
+				Value:       cli.NewStringSlice(),
+				DefaultText: "aws_rds_instance,AWS::S3::Bucket",
 			},
 		},
 	}

--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -89,6 +89,7 @@ func (p *CloudformationParser) ParseFile(filePath string) ([]structure.IBlock, e
 		parsedBlocks := make([]structure.IBlock, 0)
 		for resourceName := range template.Resources {
 			resource := template.Resources[resourceName]
+			resourceType := resource.AWSCloudFormationType()
 			lines := resourceNamesToLines[resourceName]
 			isTaggable, tagsValue := utils.StructContainsProperty(resource, TagsAttributeName)
 			tagsLines := structure.Lines{Start: -1, End: -1}
@@ -109,6 +110,7 @@ func (p *CloudformationParser) ParseFile(filePath string) ([]structure.IBlock, e
 					Lines:             *lines,
 					TagLines:          tagsLines,
 					Name:              resourceName,
+					Type:              resourceType,
 				},
 			}
 			parsedBlocks = append(parsedBlocks, cfnBlock)

--- a/src/common/clioptions/cli.go
+++ b/src/common/clioptions/cli.go
@@ -15,15 +15,16 @@ import (
 var allowedOutputTypes = []string{"cli", "json"}
 
 type TagOptions struct {
-	Directory      string
-	Tag            []string
-	SkipTags       []string
-	CustomTagging  []string
-	SkipDirs       []string
-	Output         string `validate:"output"`
-	OutputJSONFile string
-	TagGroups      []string `validate:"tagGroupNames"`
-	ConfigFile     string   `validate:"config-file"`
+	Directory         string
+	Tag               []string
+	SkipTags          []string
+	CustomTagging     []string
+	SkipDirs          []string
+	Output            string `validate:"output"`
+	OutputJSONFile    string
+	TagGroups         []string `validate:"tagGroupNames"`
+	ConfigFile        string   `validate:"config-file"`
+	SkipResourceTypes []string
 }
 
 type ListTagsOptions struct {

--- a/src/common/structure/block.go
+++ b/src/common/structure/block.go
@@ -31,6 +31,7 @@ type IBlock interface {
 	GetSeparator() string
 	GetTagsAttributeName() string
 	IsGCPBlock() bool
+	GetResourceType() string
 }
 
 type Block struct {
@@ -43,6 +44,7 @@ type Block struct {
 	Lines             Lines
 	TagLines          Lines
 	Name              string
+	Type              string
 }
 
 func (b *Block) Init(filePath string, rawBlock interface{}) {
@@ -56,6 +58,10 @@ func (b *Block) GetLines(_ ...bool) Lines {
 
 func (b *Block) GetResourceID() string {
 	return b.Name
+}
+
+func (b *Block) GetResourceType() string {
+	return b.Type
 }
 
 func (b *Block) GetTagsLines() Lines {

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -374,9 +374,10 @@ func (p *TerrraformParser) parseBlock(hclBlock *hclwrite.Block, filePath string)
 	var existingTags []tags.ITag
 	isTaggable := false
 	var tagsAttributeName string
+	var resourceType string
 	switch hclBlock.Type() {
 	case ResourceBlockType:
-		resourceType := hclBlock.Labels()[0]
+		resourceType = hclBlock.Labels()[0]
 		providerName := getProviderFromResourceType(resourceType)
 		if utils.InSlice(SkippedProviders, providerName) {
 			return nil, fmt.Errorf("resource belongs to skipped provider %s", providerName)
@@ -407,6 +408,7 @@ func (p *TerrraformParser) parseBlock(hclBlock *hclwrite.Block, filePath string)
 			return nil, nil
 		}
 	case ModuleBlockType:
+		resourceType = "module"
 		moduleSource := string(hclBlock.Body().GetAttribute("source").Expr().BuildTokens(hclwrite.Tokens{}).Bytes())
 		// source is always wrapped in " front and back
 		moduleSource = strings.Trim(moduleSource, "\" ")
@@ -438,6 +440,7 @@ func (p *TerrraformParser) parseBlock(hclBlock *hclwrite.Block, filePath string)
 			ExitingTags:       existingTags,
 			IsTaggable:        isTaggable,
 			TagsAttributeName: tagsAttributeName,
+			Type:              resourceType,
 		},
 	}
 


### PR DESCRIPTION
Example use-cases:

1. Don't want to tag any S3 buckets in the configuration
2. A new resource type is breaking Yor, and you want to temporarily
   bypass it until a fix is available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
