### PR TITLE
Fix directory filtering for external tag group

### DIFF
--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -189,14 +189,18 @@ func (t *TagGroup) CalculateTagValue(block structure.IBlock, tag Tag) (tags.ITag
 				case string:
 					retTag.Value = evaluateTemplateVariable(matchType)
 				case map[interface{}]interface{}:
+					matching := true
 					for tagName, tagMatch := range matchType["tags"].(map[interface{}]interface{}) {
 						switch tagMatch.(type) {
 						case string:
 							for _, blockTag := range blockTags {
 								blockTagKey, blockTagValue := blockTag.GetKey(), blockTag.GetValue()
-								if blockTagKey == tagName && blockTagValue == tagMatch {
-									retTag.Value = evaluateTemplateVariable(matchValue)
+								if blockTagKey == tagName {
+									matching = matching && blockTagValue == tagMatch
 								}
+							}
+							if matching {
+								retTag.Value = evaluateTemplateVariable(matchValue)
 							}
 						case []interface{}:
 							for _, blockTag := range blockTags {

--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -78,7 +78,14 @@ func (t Tag) SatisfyFilters(block structure.IBlock) bool {
 			}
 
 		case "directory":
-			prefixes := filterValue.([]string)
+			var prefixes []string
+			switch filterValue.(type) {
+			case []string:
+				prefixes = filterValue.([]string)
+			case string:
+				prefixes = []string{filterValue.(string)}
+			}
+
 			for _, p := range prefixes {
 				if strings.HasPrefix(p, block.GetFilePath()) {
 					satisfyFilters = false

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -45,7 +45,11 @@ func TestExternalTagGroup(t *testing.T) {
 				assert.Equal(t, newBlockTag.GetValue(), "master")
 			}
 		}
-		assert.Equal(t, 4, len(block.ExitingTags)+len(block.NewTags))
+		assert.Equal(t, 1, len(block.NewTags))
+		if len(block.NewTags) == 1 {
+			assert.Equal(t, "env", block.NewTags[0].GetKey())
+			assert.Equal(t, "master", block.NewTags[0].GetValue())
+		}
 	})
 
 	t.Run("test tagGroup CreateTagsForBlock matches", func(t *testing.T) {
@@ -82,7 +86,11 @@ func TestExternalTagGroup(t *testing.T) {
 			logger.Warning(err.Error())
 			t.Fail()
 		}
-		assert.Equal(t, 6, len(block.ExitingTags)+len(block.NewTags))
+		assert.Equal(t, 1, len(block.NewTags))
+		if len(block.NewTags) == 1 {
+			assert.Equal(t, "env", block.NewTags[0].GetKey())
+			assert.Equal(t, "${env:GIT_BRANCH}", block.NewTags[0].GetValue())
+		}
 	})
 
 	t.Run("test tagGroup CreateTagsForBlock matches with directory filter", func(t *testing.T) {

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -84,6 +84,53 @@ func TestSimpleTagGroup(t *testing.T) {
 		}
 		assert.Equal(t, 6, len(block.ExitingTags)+len(block.NewTags))
 	})
+
+	t.Run("test tagGroup CreateTagsForBlock matches with directory filter", func(t *testing.T) {
+		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group.yml")
+		tagGroup := TagGroup{}
+		tagGroup.InitTagGroup("", nil)
+		tagGroup.InitExternalTagGroups(confPath)
+		block := &MockTestBlock{
+			Block: structure.Block{
+				FilePath:   "src/account/main.tf",
+				IsTaggable: true,
+				ExitingTags: []tags.ITag{
+					&tags.Tag{
+						Key:   "git_modifiers",
+						Value: "tronxd",
+					},
+					&tags.Tag{
+						Key:   "git_repo",
+						Value: "yor",
+					},
+					&tags.Tag{
+						Key:   "git_commit",
+						Value: "asd12f",
+					},
+					&tags.Tag{
+						Key:   "yor_trace",
+						Value: "123",
+					},
+				},
+			},
+		}
+		err := tagGroup.CreateTagsForBlock(block)
+		if err != nil {
+			logger.Warning(err.Error())
+			t.Fail()
+		}
+		assert.Equal(t, 7, len(block.ExitingTags)+len(block.NewTags))
+		var dirTag tags.ITag
+		for _, t := range block.NewTags {
+			if t.GetKey() == "stack" {
+				dirTag = t
+				break
+			}
+		}
+		assert.NotNil(t, dirTag)
+		assert.Equal(t, dirTag.GetKey(), "stack")
+		assert.Equal(t, dirTag.GetValue(), "account")
+	})
 }
 
 type MockTestBlock struct {

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -30,7 +30,7 @@ func TestExternalTagGroup(t *testing.T) {
 					},
 					&tags.Tag{
 						Key:   "git_repo",
-						Value: "yor",
+						Value: "checkov",
 					},
 				},
 			},
@@ -46,10 +46,6 @@ func TestExternalTagGroup(t *testing.T) {
 			}
 		}
 		assert.Equal(t, 1, len(block.NewTags))
-		if len(block.NewTags) == 1 {
-			assert.Equal(t, "env", block.NewTags[0].GetKey())
-			assert.Equal(t, "master", block.NewTags[0].GetValue())
-		}
 	})
 
 	t.Run("test tagGroup CreateTagsForBlock matches", func(t *testing.T) {
@@ -89,7 +85,7 @@ func TestExternalTagGroup(t *testing.T) {
 		assert.Equal(t, 1, len(block.NewTags))
 		if len(block.NewTags) == 1 {
 			assert.Equal(t, "env", block.NewTags[0].GetKey())
-			assert.Equal(t, "${env:GIT_BRANCH}", block.NewTags[0].GetValue())
+			assert.Equal(t, "dev", block.NewTags[0].GetValue())
 		}
 	})
 

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSimpleTagGroup(t *testing.T) {
+func TestExternalTagGroup(t *testing.T) {
 
 	t.Run("test tagGroup CreateTagsForBlock default value", func(t *testing.T) {
 		_ = os.Setenv("GIT_BRANCH", "master")
@@ -86,7 +86,7 @@ func TestSimpleTagGroup(t *testing.T) {
 	})
 
 	t.Run("test tagGroup CreateTagsForBlock matches with directory filter", func(t *testing.T) {
-		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group.yml")
+		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group_dir.yml")
 		tagGroup := TagGroup{}
 		tagGroup.InitTagGroup("", nil)
 		tagGroup.InitExternalTagGroups(confPath)
@@ -119,7 +119,7 @@ func TestSimpleTagGroup(t *testing.T) {
 			logger.Warning(err.Error())
 			t.Fail()
 		}
-		assert.Equal(t, 7, len(block.ExitingTags)+len(block.NewTags))
+		assert.Equal(t, 2, len(block.NewTags))
 		var dirTag tags.ITag
 		for _, t := range block.NewTags {
 			if t.GetKey() == "stack" {
@@ -128,9 +128,50 @@ func TestSimpleTagGroup(t *testing.T) {
 			}
 		}
 		assert.NotNil(t, dirTag)
-		assert.Equal(t, dirTag.GetKey(), "stack")
-		assert.Equal(t, dirTag.GetValue(), "account")
+		if dirTag != nil {
+			assert.Equal(t, dirTag.GetKey(), "stack")
+			assert.Equal(t, dirTag.GetValue(), "account")
+		}
 	})
+
+	t.Run("test tagGroup CreateTagsForBlock not matches with directory filter", func(t *testing.T) {
+		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group_dir.yml")
+		tagGroup := TagGroup{}
+		tagGroup.InitTagGroup("", nil)
+		tagGroup.InitExternalTagGroups(confPath)
+		block := &MockTestBlock{
+			Block: structure.Block{
+				FilePath:   "src/base/main.tf",
+				IsTaggable: true,
+				ExitingTags: []tags.ITag{
+					&tags.Tag{
+						Key:   "git_modifiers",
+						Value: "tronxd",
+					},
+					&tags.Tag{
+						Key:   "git_repo",
+						Value: "yor",
+					},
+					&tags.Tag{
+						Key:   "git_commit",
+						Value: "asd12f",
+					},
+					&tags.Tag{
+						Key:   "yor_trace",
+						Value: "123",
+					},
+				},
+			},
+		}
+		err := tagGroup.CreateTagsForBlock(block)
+		if err != nil {
+			logger.Warning(err.Error())
+			t.Fail()
+		}
+		assert.Equal(t, 4, len(block.ExitingTags))
+		assert.Equal(t, 1, len(block.NewTags))
+	})
+
 }
 
 type MockTestBlock struct {

--- a/tests/external_tags/external_tag_group.yml
+++ b/tests/external_tags/external_tag_group.yml
@@ -3,13 +3,12 @@ tag_groups:
     tags:
       - name: env
         value:
-          default: dev
+          default: ${env:GIT_BRANCH}
           matches:
-            - prod: ${env:GIT_BRANCH}
-        filters:
-          tags:
-            git_repo: yor
-            git_modifiers: tronxd
+            - dev:
+                tags:
+                  git_repo: yor
+                  git_modifiers: tronxd
       - name: team
         value:
           default: interfaces

--- a/tests/external_tags/external_tag_group.yml
+++ b/tests/external_tags/external_tag_group.yml
@@ -28,3 +28,9 @@ tag_groups:
         filters:
           tags:
             git_commit: 00193660c248483862c06e2ae96111adfcb683af
+      - name: stack
+        value:
+          default: account
+        filters:
+          directory:
+            - src/account/

--- a/tests/external_tags/external_tag_group.yml
+++ b/tests/external_tags/external_tag_group.yml
@@ -28,9 +28,3 @@ tag_groups:
         filters:
           tags:
             git_commit: 00193660c248483862c06e2ae96111adfcb683af
-      - name: stack
-        value:
-          default: account
-        filters:
-          directory:
-            - src/account/

--- a/tests/external_tags/external_tag_group_dir.yml
+++ b/tests/external_tags/external_tag_group_dir.yml
@@ -1,0 +1,18 @@
+tag_groups:
+  - name: ownership
+    tags:
+      - name: env
+        value:
+          default: dev
+          matches:
+            - prod: ${env:GIT_BRANCH}
+        filters:
+          tags:
+            git_repo: yor
+            git_modifiers: tronxd
+      - name: stack
+        value:
+          default: account
+        filters:
+          directory:
+            - src/account/

--- a/tests/external_tags/external_tag_group_dir.yml
+++ b/tests/external_tags/external_tag_group_dir.yml
@@ -3,13 +3,12 @@ tag_groups:
     tags:
       - name: env
         value:
-          default: dev
+          default: ${env:GIT_BRANCH}
           matches:
-            - prod: ${env:GIT_BRANCH}
-        filters:
-          tags:
-            git_repo: yor
-            git_modifiers: tronxd
+            - dev:
+                tags:
+                  git_repo: yor
+                  git_modifiers: tronxd
       - name: stack
         value:
           default: account


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR:
1. Supports directory filtering for external tag groups
2. Fixes logic to support AND between different filters. Example:
    ```yaml
    tags: 
      git_repo: yor
      git_modifiers: tronxd
    ```
    Used to apply the tag to any block which either is part of the `yor` repo or was modified by `tronxd`. After this PR - the block will have to comply to both requirements