### PR TITLE
fix: use zip archive for windows builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,13 @@ builds:
       - goarch: 386
         goos: darwin
 
+archives:
+  - id: yor
+    builds:
+    - yor
+    format_overrides:
+      - goos: windows
+        format: zip
 
 brews:
   -


### PR DESCRIPTION
Ensuring when build is performed the windows build is as a .zip

Fixes #193

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
