### PR TITLE
Close terraform clients after completion

### DIFF
--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -50,6 +50,10 @@ func (p *CloudformationParser) Init(rootDir string, _ map[string]string) {
 	}
 }
 
+func (p CloudformationParser) Close() {
+	return
+}
+
 func (p *CloudformationParser) GetSkippedDirs() []string {
 	return []string{}
 }

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -10,4 +10,5 @@ type IParser interface {
 	WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error
 	GetSkippedDirs() []string
 	GetSupportedFileExtensions() []string
+	Close()
 }

--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -116,6 +116,10 @@ func (r *Runner) TagDirectory() (*reports.ReportService, error) {
 	}
 	wg.Wait()
 
+	for _, parser := range r.parsers {
+		parser.Close()
+	}
+
 	return r.reportingService, nil
 }
 

--- a/src/serverless/structure/serverless_parser.go
+++ b/src/serverless/structure/serverless_parser.go
@@ -34,6 +34,10 @@ func (p *ServerlessParser) Init(rootDir string, _ map[string]string) {
 	p.YamlParser.RootDir = rootDir
 }
 
+func (p *ServerlessParser) Close() {
+	return
+}
+
 func (p *ServerlessParser) GetSkippedDirs() []string {
 	return []string{}
 }

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -64,6 +64,14 @@ func (p *TerrraformParser) Init(rootDir string, args map[string]string) {
 	p.moduleInstallDir = filepath.Join(pwd, ".terraform", "modules")
 }
 
+func (p *TerrraformParser) Close() {
+	p.providerToClientMap.Range(func(provider, iClient interface{}) bool {
+		client := iClient.(tfschema.Client)
+		client.Close()
+		return true
+	})
+}
+
 func (p *TerrraformParser) GetSkippedDirs() []string {
 	return ignoredDirs
 }


### PR DESCRIPTION
Added a `Close` method to all parsers to allow running code after tagging is complete, for example - close terraform GRPC clients.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
