### PR TITLE
Removed unnecessary apk update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk update && apk --no-cache add build-base git curl jq bash
+RUN apk --no-cache add build-base git curl jq bash
 RUN curl -s -k https://api.github.com/repos/bridgecrewio/yor/releases/latest | jq '.assets[] | select(.name | contains("linux_386")) | select(.content_type | contains("gzip")) | .browser_download_url' -r | awk '{print "curl -L -k " $0 " -o /usr/bin/yor.tar.gz"}' | sh
 RUN tar -xf /usr/bin/yor.tar.gz -C /usr/bin/ && rm /usr/bin/yor.tar.gz && chmod +x /usr/bin/yor && echo 'alias yor="/usr/bin/yor"' >> ~/.bashrc
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# Description
- When using `apk add --no-cache`  unnecessary `apk update`

## FYI
- https://github.com/bridgecrewio/checkov/pull/1723
- https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
