### PR TITLE
Added arm build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,10 @@ builds:
     goarch:
       - 386
       - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
     ignore:
       - goarch: 386
         goos: darwin


### PR DESCRIPTION
# Description
- I using M1 Mac failed `brew tap`. I added arm build setting.

```
brew tap bridgecrewio/tap

==> Tapping bridgecrewio/tap
Cloning into '/opt/homebrew/Library/Taps/bridgecrewio/homebrew-tap'...
remote: Enumerating objects: 447, done.
remote: Counting objects: 100% (447/447), done.
remote: Compressing objects: 100% (308/308), done.
remote: Total 447 (delta 140), reused 21 (delta 4), pack-reused 0
Receiving objects: 100% (447/447), 51.38 KiB | 1.19 MiB/s, done.
Resolving deltas: 100% (140/140), done.
Error: Invalid formula: /opt/homebrew/Library/Taps/bridgecrewio/homebrew-tap/yor.rb
formulae require at least a URL
Error: Cannot tap bridgecrewio/tap: invalid syntax in tap!
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
