### PR TITLE
Mute Terraform logs if requested

### DIFF
--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -67,7 +67,9 @@ func (p *TerrraformParser) Init(rootDir string, args map[string]string) {
 func (p *TerrraformParser) Close() {
 	p.providerToClientMap.Range(func(provider, iClient interface{}) bool {
 		client := iClient.(tfschema.Client)
+		logger.MuteLogging()
 		client.Close()
+		logger.UnmuteLogging()
 		return true
 	})
 }


### PR DESCRIPTION
Fixed the `MuteLogging/UnmuteLogging` by using the atomic int - if a mute is already in place don't mute again, and if there is still a thread that is muted don't unmute.
Also muted loges from closing the terraform client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
