### PR TITLE
Fix isFile predicate - skip dirs correctly

### DIFF
--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -268,7 +268,7 @@ func extractExternalResources(plug *plugin.Plugin, symbol string) ([]interface{}
 func (r *Runner) isFileSkipped(p common.IParser, file string) bool {
 	relPath, _ := filepath.Rel(r.dir, file)
 	for _, sp := range r.skipDirs {
-		if strings.HasPrefix(relPath, sp) {
+		if strings.HasPrefix(r.dir+"/"+relPath, sp) {
 			return true
 		}
 	}

--- a/src/common/runner/runner_test.go
+++ b/src/common/runner/runner_test.go
@@ -155,7 +155,11 @@ func TestRunnerInternals(t *testing.T) {
 	t.Run("Test isFileSkipped", func(t *testing.T) {
 		runner := Runner{}
 		rootDir := "../../../tests/terraform"
-		skippedFiles := []string{"../../../tests/terraform/mixed/mixed.tf", "../../../tests/terraform/resources/tagged/complex_tags_tagged.tf"}
+		skippedFiles := []string{
+			"../../../tests/terraform/mixed/mixed.tf",
+			"../../../tests/terraform/resources/tagged/complex_tags_tagged.tf",
+			"../../../tests/terraform/resources/tagged/expected.txt",
+		}
 		_ = runner.Init(&clioptions.TagOptions{
 			Directory: rootDir,
 			SkipDirs:  []string{"../../../tests/terraform/mixed", "../../../tests/terraform/resources/tagged/"},
@@ -184,7 +188,7 @@ func TestRunnerInternals(t *testing.T) {
 			return nil
 		})
 
-		assert.Equal(t, 2, len(skippedFiles), "Some files were not skipped")
+		assert.Equal(t, 1, len(skippedFiles), "Some files were not skipped")
 	})
 
 	t.Run("Test skip entire dir", func(t *testing.T) {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #252 