### PR TITLE
Fix GoSec Test

### DIFF
--- a/src/common/yaml/yaml_writer.go
+++ b/src/common/yaml/yaml_writer.go
@@ -20,9 +20,8 @@ import (
 const SingleIndent = "  "
 
 func WriteYAMLFile(readFilePath string, blocks []structure.IBlock, writeFilePath string, tagsAttributeName string, resourcesStartToken string) error {
-	// read file bytes
-
 	// #nosec G304
+	// read file bytes
 	originFileSrc, err := ioutil.ReadFile(readFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s because %s", readFilePath, err)

--- a/src/common/yaml/yaml_writer.go
+++ b/src/common/yaml/yaml_writer.go
@@ -21,6 +21,7 @@ const SingleIndent = "  "
 
 func WriteYAMLFile(readFilePath string, blocks []structure.IBlock, writeFilePath string, tagsAttributeName string, resourcesStartToken string) error {
 	// read file bytes
+
 	// #nosec G304
 	originFileSrc, err := ioutil.ReadFile(readFilePath)
 	if err != nil {

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -118,6 +118,7 @@ func (p *TerrraformParser) ValidFile(_ string) bool {
 
 func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error) {
 	// read file bytes
+
 	// #nosec G304
 	src, err := ioutil.ReadFile(filePath)
 	if err != nil {
@@ -172,6 +173,7 @@ func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error
 
 func (p *TerrraformParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error {
 	// read file bytes
+
 	// #nosec G304
 	src, err := ioutil.ReadFile(readFilePath)
 	if err != nil {

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -117,9 +117,8 @@ func (p *TerrraformParser) ValidFile(_ string) bool {
 }
 
 func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error) {
-	// read file bytes
-
 	// #nosec G304
+	// read file bytes
 	src, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s because %s", filePath, err)
@@ -172,9 +171,8 @@ func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error
 }
 
 func (p *TerrraformParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error {
-	// read file bytes
-
 	// #nosec G304
+	// read file bytes
 	src, err := ioutil.ReadFile(readFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s because %s", readFilePath, err)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

Gosec tests are failing due to https://github.com/securego/gosec/issues/743

This PR fixes the issue by switching the order of the affected GoSec annotations and comments.