### PR TITLE
External config file tags matching 

### DIFF
--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -196,12 +196,14 @@ func (t *TagGroup) CalculateTagValue(block structure.IBlock, tag Tag) (tags.ITag
 				case map[interface{}]interface{}:
 					matching := true
 					for tagName, tagMatch := range matchType["tags"].(map[interface{}]interface{}) {
+						foundTag := false
 						switch tagMatch.(type) {
 						case string:
 							for _, blockTag := range blockTags {
 								blockTagKey, blockTagValue := blockTag.GetKey(), blockTag.GetValue()
-								if blockTagKey == tagName {
-									matching = matching && blockTagValue == tagMatch
+								if blockTagKey == tagName && blockTagValue == tagMatch {
+									foundTag = true
+									break
 								}
 							}
 						case []interface{}:
@@ -211,19 +213,22 @@ func (t *TagGroup) CalculateTagValue(block structure.IBlock, tag Tag) (tags.ITag
 									if blockTagKey == tags.GitModifiersTagKey {
 										for _, val := range strings.Split(blockTagValue, "/") {
 											if utils.InSlice(tagMatch, val) {
-												retTag.Value = matchValue
+												foundTag = true
 												break
 											}
 										}
 									} else if utils.InSlice(tagMatch, blockTagValue) {
-										retTag.Value = matchValue
+										foundTag = true
+										break
 									}
 								}
 							}
 						}
+						matching = matching && foundTag
 					}
 					if matching {
 						retTag.Value = evaluateTemplateVariable(matchValue)
+						break
 					}
 				}
 			}

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -176,6 +176,39 @@ func TestExternalTagGroup(t *testing.T) {
 		assert.Equal(t, 1, len(block.NewTags))
 	})
 
+	t.Run("test tagGroup CreateTagsForBlock no matches", func(t *testing.T) {
+		_ = os.Setenv("GIT_BRANCH", "master")
+		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group_no_match.yml")
+		tagGroup := TagGroup{}
+		tagGroup.InitTagGroup("", nil)
+		tagGroup.InitExternalTagGroups(confPath)
+		block := &MockTestBlock{
+			Block: structure.Block{
+				FilePath:   "src/base/main.tf",
+				IsTaggable: true,
+				ExitingTags: []tags.ITag{
+					&tags.Tag{
+						Key:   "git_modifiers",
+						Value: "tronxd",
+					},
+					&tags.Tag{
+						Key:   "git_repo",
+						Value: "yor",
+					},
+				},
+			},
+		}
+		err := tagGroup.CreateTagsForBlock(block)
+		if err != nil {
+			logger.Warning(err.Error())
+			t.Fail()
+		}
+		for _, newBlockTag := range block.GetNewTags() {
+			if newBlockTag.GetKey() == "env" {
+				assert.Equal(t, "master", newBlockTag.GetValue())
+			}
+		}
+	})
 }
 
 type MockTestBlock struct {

--- a/tests/external_tags/external_tag_group_no_match.yml
+++ b/tests/external_tags/external_tag_group_no_match.yml
@@ -1,0 +1,20 @@
+tag_groups:
+  - name: ownership
+    tags:
+      - name: env
+        value:
+          default: ${env:GIT_BRANCH}
+          matches:
+            - not_exist_match1:
+                tags:
+                  git_modifiers: tronxd
+                  not_exist_str_val1: not_exist_val
+            - not_exist_match2:
+                tags:
+                  not_exist_array_val:
+                    - not_exist_val1
+                    - not_exist_val2
+                  git_repo: yor
+            - not_exist_match3:
+                tags:
+                  not_exist_str_val2: not_exist_val2


### PR DESCRIPTION
Handle cases where a tag in matches does not exist/its value does not match - expected behavior is to fallback into the default value. prior to the fix the matched tag value would be the last match entry name 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
