### PR TITLE
Fix race condition in logs

### DIFF
--- a/src/common/logger/logging_service_test.go
+++ b/src/common/logger/logging_service_test.go
@@ -59,17 +59,19 @@ func TestLogger(t *testing.T) {
 
 	t.Run("Test mute and unmute", func(t *testing.T) {
 		Logger.SetLogLevel("WARNING")
-		MuteLogging()
+
+		var result string
 		infoMsg := "Test muted INFO"
-		result := utils.CaptureOutput(func() { Info(infoMsg) })
-		assert.Equal(t, "", result)
 		warningMsg := "Test muted WARNING"
-		result = utils.CaptureOutput(func() { Warning(warningMsg) })
-		assert.Equal(t, "", result)
 		debugMsg := "Test muted DEBUG"
-		result = utils.CaptureOutput(func() { Debug(debugMsg) })
-		assert.Equal(t, "", result)
-		UnmuteLogging()
+		MuteOutputBlock(func() {
+			result = utils.CaptureOutput(func() { Info(infoMsg) })
+			assert.Equal(t, "", result)
+			result = utils.CaptureOutput(func() { Warning(warningMsg) })
+			assert.Equal(t, "", result)
+			result = utils.CaptureOutput(func() { Debug(debugMsg) })
+			assert.Equal(t, "", result)
+		})
 		Logger.SetLogLevel("DEBUG")
 		result = utils.CaptureOutput(func() { Info(infoMsg) })
 		assert.True(t, strings.Contains(result, infoMsg))

--- a/src/terraform/structure/terraform_module.go
+++ b/src/terraform/structure/terraform_module.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform/tfdiags"
+
 	"github.com/bridgecrewio/yor/src/common/logger"
 	"github.com/bridgecrewio/yor/src/common/utils"
 
@@ -64,9 +66,11 @@ func (t *TerraformModule) InitProvider() {
 			return
 		}
 		pty := addrs.NewLegacyProvider(provider)
-		logger.MuteLogging()
-		_, diagnostics, err := providerInstaller.Get(pty, constraints.Versions)
-		logger.UnmuteLogging()
+		var err error
+		var diagnostics tfdiags.Diagnostics
+		logger.MuteOutputBlock(func() {
+			_, diagnostics, err = providerInstaller.Get(pty, constraints.Versions)
+		})
 		if (diagnostics != nil && diagnostics.HasErrors()) || err != nil {
 			errMsg := diagnostics.Err()
 			if errMsg == nil {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fix race condition that occurs in logs methods MuteLogging & UnmuteLogging.
The fix is atomic block of code that won’t send logs to the output.

```
WARNING: DATA RACE
Write at 0x0000058278f8 by goroutine 263:
  github.com/bridgecrewio/yor/src/common/logger.MuteLogging()
      /actions-runner/_work/yor/yor/src/common/logger/logging_service.go:126 +0xfe
  github.com/bridgecrewio/yor/src/terraform/structure.(*TerrraformParser).isBlockTaggable()
      /actions-runner/_work/yor/yor/src/terraform/structure/terraform_parser.go:649 +0x4a4
  github.com/bridgecrewio/yor/src/terraform/structure.(*TerrraformParser).parseBlock()
      /actions-runner/_work/yor/yor/src/terraform/structure/terraform_parser.go:469 +0x706
  github.com/bridgecrewio/yor/src/terraform/structure.(*TerrraformParser).ParseFile()
      /actions-runner/_work/yor/yor/src/terraform/structure/terraform_parser.go:151 +0x604
  github.com/bridgecrewio/yor/src/common/runner.(*Runner).TagFile()
      /actions-runner/_work/yor/yor/src/common/runner/runner.go:166 +0x375
  github.com/bridgecrewio/yor/src/common/runner.(*Runner).worker()
      /actions-runner/_work/yor/yor/src/common/runner/runner.go:109 +0x64

Previous read at 0x0000058278f8 by goroutine 61:
  github.com/bridgecrewio/yor/src/common/logger.UnmuteLogging()
      /actions-runner/_work/yor/yor/src/common/logger/logging_service.go:139 +0x9b
  github.com/bridgecrewio/yor/src/terraform/structure.(*TerrraformParser).isBlockTaggable()
      /actions-runner/_work/yor/yor/src/terraform/structure/terraform_parser.go:651 +0x505
  github.com/bridgecrewio/yor/src/terraform/structure.(*TerrraformParser).parseBlock()
      /actions-runner/_work/yor/yor/src/terraform/structure/terraform_parser.go:469 +0x706
  github.com/bridgecrewio/yor/src/terraform/structure.(*TerrraformParser).ParseFile()
      /actions-runner/_work/yor/yor/src/terraform/structure/terraform_parser.go:151 +0x604
  github.com/bridgecrewio/yor/src/common/runner.(*Runner).TagFile()
      /actions-runner/_work/yor/yor/src/common/runner/runner.go:166 +0x375
  github.com/bridgecrewio/yor/src/common/runner.(*Runner).worker()
      /actions-runner/_work/yor/yor/src/common/runner/runner.go:109 +0x64
```