### PR TITLE
Detect scalr.io module references as remote so they can be tagged

### DIFF
--- a/src/terraform/structure/terraform_module.go
+++ b/src/terraform/structure/terraform_module.go
@@ -173,7 +173,7 @@ func isRemoteModule(s string) bool {
 	// Taken from https://www.terraform.io/docs/language/modules/sources.html
 	return strings.HasPrefix(s, "git::") || strings.HasPrefix(s, "hg::") || strings.HasPrefix(s, "s3::") || strings.HasPrefix(s, "gcs::") ||
 		strings.HasPrefix(s, "github.com/") || strings.HasPrefix(s, "bitbucket.org/") || strings.HasPrefix(s, "app.terraform.io/") ||
-		strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "git@")
+		strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "git@") || strings.Contains(s, ".scalr.io")
 }
 
 func isTerraformRegistryModule(source string) bool {

--- a/src/terraform/structure/terraform_module_test.go
+++ b/src/terraform/structure/terraform_module_test.go
@@ -16,6 +16,11 @@ func TestTerrraformModule(t *testing.T) {
 		assert.True(t, isRemote)
 	})
 
+	t.Run("Test TF Module remote scalr logic", func(t *testing.T) {
+		isRemote := isRemoteModule("jameswoolfenden.scalr.io/acc-u1ksa0vgdflusgo/cloudfront/aws")
+		assert.True(t, isRemote)
+	})
+
 	t.Run("Test TF Module remote github logic", func(t *testing.T) {
 		isRemote := isRemoteModule("github.com/terraform-aws-modules/terraform-aws-vpc.git")
 		assert.True(t, isRemote)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
