### PR TITLE
Change protocol for pre-commit config in documentation

### DIFF
--- a/docs/2.Using Yor/applyTag.md
+++ b/docs/2.Using Yor/applyTag.md
@@ -42,7 +42,7 @@ You need to have the pre-commit package manager installed before you can run Pre
 Add a hook to your **.pre-commit-config.yaml** and change the args and version number.
 
 ```yaml
-  - repo: git://github.com/bridgecrewio/yor
+  - repo: https://github.com/bridgecrewio/yor
     rev: 0.0.44
     hooks:
       - id: yor


### PR DESCRIPTION
The `git://` protcol wrapper is no longer supported by GitHub. When attempting to configure pre-commit like this, it throws an error:

```
$ pre-commit run --all-files
[INFO] Initializing environment for git://github.com/bridgecrewio/yor.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Changing it to `https://` does work as expected.