### PR TITLE
docs: fix the revision of Yor in Pre-Commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ jobs:
 
 Pre-commit
 ```yaml
-  - repo: git://github.com/bridgecrewio/yor
-    rev: 0.0.44
+  - repo: https://github.com/bridgecrewio/yor
+    rev: 0.1.143
     hooks:
       - id: yor
         name: yor
         entry: yor tag -d
-        args: ["example/examplea"]
+        args: ["."]
         language: golang
         types: [terraform]
         pass_filenames: false


### PR DESCRIPTION
Yor version was outdated in Pre-Commit hook. And as far as I remember the git protocol shouldn't be used anymore.

Tested with `pre-commit install` that this configuration is accepted.