### PR TITLE
Handle nil terraformModule before creating tfschema client

### DIFF
--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -760,6 +760,10 @@ func (p *TerrraformParser) getClient(providerName string) tfschema.Client {
 	})
 	var err error
 	var newClient tfschema.Client
+	if p.terraformModule == nil {
+		logger.Warning(fmt.Sprintf("Failed to initialize terraform module, it might be due to a malformed file in the given root dir: [%s]", p.rootDir))
+		return nil
+	}
 	logger.MuteOutputBlock(func() {
 		newClient, err = tfschema.NewClient(providerName, tfschema.Option{
 			RootDir: p.terraformModule.ProvidersInstallDir,

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -125,6 +125,16 @@ func TestTerrraformParser_ParseFile(t *testing.T) {
 		assert.Nil(t, parsedBlocks)
 		assert.NotNil(t, err)
 	})
+
+	t.Run("Do not crash if getting malformed file", func(t *testing.T) {
+		p := &TerrraformParser{}
+		p.Init("../../../tests/terraform/malformed_file_in_dir", nil)
+		defer p.Close()
+		filePath := "../../../tests/terraform/resources/malformed_file_in_dir/trail.tf"
+		parsedBlocks, err := p.ParseFile(filePath)
+		assert.Nil(t, parsedBlocks)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestTerrraformParser(t *testing.T) {

--- a/tests/terraform/malformed_file_in_dir/malformed.tf
+++ b/tests/terraform/malformed_file_in_dir/malformed.tf
@@ -1,0 +1,1 @@
+not terraform!!

--- a/tests/terraform/malformed_file_in_dir/trail.tf
+++ b/tests/terraform/malformed_file_in_dir/trail.tf
@@ -1,0 +1,33 @@
+resource "alicloud_actiontrail_trail" "fail" {
+  # Action Trail not Logging for all regions
+  # Action Trail not Logging for all events
+  trail_name         = "action-trail"
+  oss_write_role_arn = alicloud_ram_role.trail.arn
+  oss_bucket_name    = alicloud_oss_bucket.trail.bucket
+  event_rw           = "Read"
+  trail_region       = "cn-hangzhou"
+}
+
+resource "alicloud_oss_bucket" "trail" {
+}
+
+resource "alicloud_ram_role" "trail" {
+  name     = "trail"
+  document = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": [
+            "actiontrail.aliyuncs.com"
+          ]
+        }
+      }
+    ],
+    "Version": "1"
+  }
+  EOF
+  force    = true
+}


### PR DESCRIPTION
In case a directory has a malformed file, we might fail to initialize `terraformModule`, and in that case, it'll be nil.
In order to prevent exceptions, I'm checking that `terraformModule != nil`, and if it is - log a warning and continue without crashing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
