### PR TITLE
Add depth check for brace and paren to fix #297

### DIFF
--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -394,7 +394,7 @@ func (p *TerrraformParser) extractTagKeysFromRawTokens(rawTagsTokens hclwrite.To
 				continue
 			}
 		case "=", "\n", ",":
-			if depth == 0 {
+			if depth == 1 {
 				possibleTagKeys = append(possibleTagKeys, currentToken)
 				currentToken = ""
 			}

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -95,6 +95,7 @@ func TestTerrraformParser_ParseFile(t *testing.T) {
 			"instance_merged_override":                  {"Environment": "new_env"},
 			"aurora_cluster_bastion_auto_scaling_group": {"git_org": "bridgecrewio", "git_repo": "platform", "yor_trace": "48564943-4cfc-403c-88cd-cbb207e0d33e", "Name": "bc-aurora-bastion"},
 			"instance_null_tags":                        nil,
+			"nested_brace_tags":                         {"Name": `lookup({Name = "tag-for-vpc", Environment = "prod", yor_trace = "should_not_use_this_id" }, "Name", "default")`},
 		}
 
 		parsedBlocks, err := p.ParseFile(filePath)

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -147,7 +147,7 @@ func TestTerrraformParser(t *testing.T) {
 		actualFiles, err := terraformParser.GetSourceFiles(directory)
 		assert.Equal(t, len(expectedFiles), len(actualFiles))
 		for _, file := range actualFiles {
-			splitFile := strings.Split(file, "/")
+			splitFile := strings.Split(file, string(os.PathSeparator))
 			lastTwoParts := splitFile[len(splitFile)-2:]
 			assert.True(t, utils.InSlice(expectedFiles, strings.Join(lastTwoParts, "/")), fmt.Sprintf("expected file %s to be in directory\n", file))
 		}

--- a/tests/terraform/resources/complex_tags.tf
+++ b/tests/terraform/resources/complex_tags.tf
@@ -83,3 +83,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   max_size = 0
   min_size = 0
 }
+
+resource "aws_vpc" "nested_brace_tags" {
+  cidr_block = ""
+  tags = {Name = lookup({Name = "tag-for-vpc", Environment = "prod", yor_trace = "should_not_use_this_id" }, "Name", "default")}
+}

--- a/tests/terraform/resources/tagged/complex_tags_tagged.tf
+++ b/tests/terraform/resources/tagged/complex_tags_tagged.tf
@@ -127,3 +127,8 @@ resource "aws_instance" "instance_no_tags" {
     yor_trace            = "a51f6e65-cd2d-4f53-962c-0d2894fc6418"
   }
 }
+
+resource "aws_vpc" "nested_brace_tags" {
+  cidr_block = ""
+  tags = {Name = lookup({Name = "tag-for-vpc", Environment = "prod", yor_trace = "should_not_use_this_id" }, "Name", "default")}
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This patch added a depth check for brace and paren to fix incorrect tag value parse.