### PR TITLE
Fix error in GitLab integration docs

### DIFF
--- a/docs/2.Using Yor/installation.md
+++ b/docs/2.Using Yor/installation.md
@@ -48,7 +48,7 @@ run-yor:
   script:
     - git checkout ${CI_COMMIT_REF_NAME}
     - export YOR_VERSION=0.1.62
-    - wget -q -O - https://github.com/bridgecrewio/yor/releases/download/${YOR_VERSION}/yor-${YOR_VERSION}-linux-amd64.tar.gz | tar -xvz -C /tmp
+    - wget -q -O - https://github.com/bridgecrewio/yor/releases/download/${YOR_VERSION}/yor_${YOR_VERSION}_linux_amd64.tar.gz | tar -xvz -C /tmp
     - /tmp/yor tag -d .
     - *git-script
 ```


### PR DESCRIPTION
This PR corrects an error in the documentation section "Integrate Yor with GitLab CI", by replacing dashes with underscores in the URL for downloading Yor from Github.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
