### PR TITLE
fix: adding sops as an skipped provider

### DIFF
--- a/src/terraform/structure/terraform_module.go
+++ b/src/terraform/structure/terraform_module.go
@@ -23,7 +23,7 @@ import (
 
 const PluginsOutputDir = ".yor_plugins"
 
-var SkippedProviders = []string{"null", "random", "tls", "local"}
+var SkippedProviders = []string{"null", "random", "tls", "local", "sops"}
 var RegistryModuleRegex = regexp.MustCompile("^((?P<MODULE_HOSTNAME>[^/]+)/)?(?P<MODULE_NAMESPACE>[^/]+)/(?P<MODULE_NAME>[^/]+)/(?P<PROVIDER>[a-z]+)")
 
 type TerraformModule struct {


### PR DESCRIPTION
This PR adds SOPS(https://registry.terraform.io/providers/carlpett/sops/0.7.1) as an skipped provider as it doesn't support tagging. 
Trying to run yor as a pre-commit hook with sops as a provider will fail with the following message:
![Screenshot 2022-11-28 at 11 01 18](https://user-images.githubusercontent.com/100706420/204296425-dde99918-e1c4-4b1c-ab10-73dd7156dfe9.png)

