### PR TITLE
fix file close temp files(windows) and add support for gcp labels in modules

### DIFF
--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -232,7 +232,10 @@ func (p *TerrraformParser) WriteFile(readFilePath string, blocks []structure.IBl
 		return err
 	}
 
-	fd.Close()
+	//cant delete files on windows if you dont close them
+	if err = fd.Close(); err != nil {
+		return err
+	}
 	err = os.Remove(tempFile.Name())
 	if err != nil {
 		return err

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -3,6 +3,7 @@ package structure
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -125,7 +126,7 @@ func (p *TerrraformParser) ValidFile(_ string) bool {
 func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error) {
 	// #nosec G304
 	// read file bytes
-	src, err := os.ReadFile(filePath)
+	src, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s because %s", filePath, err)
 	}
@@ -179,7 +180,7 @@ func (p *TerrraformParser) ParseFile(filePath string) ([]structure.IBlock, error
 func (p *TerrraformParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error {
 	// #nosec G304
 	// read file bytes
-	src, err := os.ReadFile(readFilePath)
+	src, err := ioutil.ReadFile(readFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s because %s", readFilePath, err)
 	}
@@ -208,7 +209,7 @@ func (p *TerrraformParser) WriteFile(readFilePath string, blocks []structure.IBl
 		}
 	}
 
-	tempFile, err := os.CreateTemp(filepath.Dir(readFilePath), "temp.*.tf")
+	tempFile, err := ioutil.TempFile(filepath.Dir(readFilePath), "temp.*.tf")
 	if err != nil {
 		return err
 	}
@@ -253,9 +254,7 @@ func (p *TerrraformParser) WriteFile(readFilePath string, blocks []structure.IBl
 	if err = f.Close(); err != nil {
 		return err
 	}
-	if err = fd.Close(); err != nil {
-		return err
-	}
+
 	return nil
 }
 
@@ -572,7 +571,7 @@ func (p *TerrraformParser) isModuleTaggable(fp string, moduleName string, tagAtt
 		return false, ""
 	}
 
-	files, _ := os.ReadDir(expectedModuleDir)
+	files, _ := ioutil.ReadDir(expectedModuleDir)
 	for _, f := range files {
 		if strings.HasSuffix(f.Name(), ".tf") {
 			blocks, _ := p.ParseFile(filepath.Join(expectedModuleDir, f.Name()))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
The write back of files was failing on windows as the file had not been closed.

Ioutil has been deprecated so i replaced it where used.

GCP labels weren't being applied at the module level  because label!=tag. Added label to the list of module tag-gable items.

Why 3 fixes in one and via a fork? ~Global protect is why.