### PR TITLE
fix build process: dont need to test 1.16 as we aren't releasing it

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go: [ 1.16, 1.17 ]
+        go: [ 1.17 ]
     runs-on: [self-hosted, public, linux, x64]
     steps:
       - name: Install Go
@@ -39,7 +39,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        go: [ 1.16, 1.17 ]
+        go: [ 1.17 ]
     runs-on: [self-hosted, public, linux, x64]
     steps:
       - name: Install Go


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
