### PR TITLE
Improve automation & bot user skipping

### DIFF
--- a/src/common/gitservice/blame.go
+++ b/src/common/gitservice/blame.go
@@ -13,10 +13,10 @@ import (
 )
 
 var CIRegexStrings = []string{
-	"\bci\b",
+	"\\bci\\b",
 	"\\[bot]",
 	"github-action",
-	"\bautomation\b",
+	"\\bautomation\\b",
 }
 
 type GitBlame struct {

--- a/src/common/gitservice/blame.go
+++ b/src/common/gitservice/blame.go
@@ -39,9 +39,13 @@ func NewGitBlame(filePath string, lines structure.Lines, blameResult *git.BlameR
 		}
 		gitBlame.BlamesByLine[line+1] = blameResult.Lines[line]
 	}
+	PrepareCIRegex(gitBlame)
+	return &gitBlame
+}
+
+func PrepareCIRegex(gitBlame GitBlame) {
 	ciRegexp, _ := regexp.Compile("(" + strings.Join(CIRegexStrings, "|") + ")")
 	gitBlame.CIRegex = ciRegexp
-	return &gitBlame
 }
 
 func (g *GitBlame) GetLatestCommit() (latestCommit *git.Line) {

--- a/src/common/gitservice/blame.go
+++ b/src/common/gitservice/blame.go
@@ -14,7 +14,7 @@ import (
 
 var CIRegexStrings = []string{
 	"\bci\b",
-	"[bot]",
+	"\\[bot]",
 	"github-action",
 	"\bautomation\b",
 }

--- a/src/common/gitservice/git_service_test.go
+++ b/src/common/gitservice/git_service_test.go
@@ -82,7 +82,7 @@ func TestNewGitService(t *testing.T) {
 		assert.Equal(t, "d68d2897add9bc2203a5ed0632a5cdd8ff8cefb0", commit.Hash.String())
 	})
 
-	t.Run("Get blame for lines test", func(t *testing.T) {
+	t.Run("Get blame for lines test 2", func(t *testing.T) {
 		terragoatPath := utils.CloneRepo(utils.TerragoatURL, "52d676e1cd75a13f990f1caca51d6ad8c78858da")
 		defer func() {
 			_ = os.RemoveAll(terragoatPath)

--- a/src/common/runner/runner_test.go
+++ b/src/common/runner/runner_test.go
@@ -52,6 +52,8 @@ func Test_loadExternalTags(t *testing.T) {
 			}, 1: {Author: "shati",
 				Date: yesterday,
 				Hash: plumbing.NewHash("1")}}}
+
+		gitservice.PrepareCIRegex(gitBlame)
 		for _, tag := range gotTags {
 			tag.Init()
 			tagVal, err := tag.CalculateValue(&gitBlame)

--- a/tests/utils/blameutils/blame.go
+++ b/tests/utils/blameutils/blame.go
@@ -2,8 +2,6 @@ package blameutils
 
 import (
 	"math/rand"
-	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -66,7 +64,7 @@ func SetupBlame(t *testing.T) gitservice.GitBlame {
 		},
 	}
 
-	blame.CIRegex, _ = regexp.Compile("(" + strings.Join(gitservice.CIRegexStrings, "|") + ")")
+	gitservice.PrepareCIRegex(blame)
 
 	return blame
 }

--- a/tests/utils/blameutils/blame.go
+++ b/tests/utils/blameutils/blame.go
@@ -2,6 +2,8 @@ package blameutils
 
 import (
 	"math/rand"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,7 +55,7 @@ func GetGitLines(t *testing.T, numOfLines int) []*git.Line {
 func SetupBlame(t *testing.T) gitservice.GitBlame {
 	gitLines := GetGitLines(t, 3)
 
-	return gitservice.GitBlame{
+	blame := gitservice.GitBlame{
 		GitOrg:        Org,
 		GitRepository: Repository,
 		FilePath:      FilePath,
@@ -63,6 +65,10 @@ func SetupBlame(t *testing.T) gitservice.GitBlame {
 			2: gitLines[2],
 		},
 	}
+
+	blame.CIRegex, _ = regexp.Compile("(" + strings.Join(gitservice.CIRegexStrings, "|") + ")")
+
+	return blame
 }
 
 func SetupBlameResults(t *testing.T, path string, numOfLines int) *git.BlameResult {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This PR allows for more extensible and deeper identification of ci users, to avoid tagging and re-tagging with the same user and to keep the actual, human committers as owners of their infra