### PR TITLE
Add support for turning yor tag on/off in tags

### DIFF
--- a/src/common/tagging/tags/tag.go
+++ b/src/common/tagging/tags/tag.go
@@ -16,6 +16,7 @@ const GitModifiersTagKey = "git_modifiers"
 const GitLastModifiedAtTagKey = "git_last_modified_at"
 const GitLastModifiedByTagKey = "git_last_modified_by"
 const GitRepoTagKey = "git_repo"
+const YorToggle = "yor_toggle"
 
 type ITag interface {
 	Init()

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -31,7 +31,7 @@ var unsupportedTerraformBlocks = []string{
 	"aws_lb_listener_rule",                   // This resource does not support tags, although docs state otherwise.
 	"aws_cloudwatch_log_destination",         // This resource does not support tags, although docs state otherwise.
 	"google_monitoring_notification_channel", //This resource uses labels for other purposes.
-	"aws_secretsmanager_secret_rotation",         // This resource does not support tags, although tfschema states otherwise.
+	"aws_secretsmanager_secret_rotation",     // This resource does not support tags, although tfschema states otherwise.
 }
 
 var taggableResourcesLock sync.RWMutex
@@ -492,6 +492,19 @@ func (p *TerraformParser) parseBlock(hclBlock *hclwrite.Block, filePath string) 
 			}
 		}()
 		isTaggable, existingTags, tagsAttributeName = p.extractTagsFromModule(hclBlock, filePath, isTaggable, existingTags, tagsAttributeName)
+	}
+
+	for _, existingTag := range existingTags {
+		if existingTag.GetKey() == tags.YorToggle {
+			v, err := strconv.ParseBool(existingTag.GetValue())
+			if err != nil {
+				continue
+			}
+
+			if !v {
+				isTaggable = false
+			}
+		}
 	}
 
 	terraformBlock := TerraformBlock{

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -498,6 +498,18 @@ func TestTerraformParser_Module(t *testing.T) {
 			assert.True(t, block.IsBlockTaggable(), fmt.Sprintf("Block %v should be taggable", block.GetResourceID()))
 		}
 	})
+
+	t.Run("Test isModuleTaggable with yor_toggle set to false", func(t *testing.T) {
+		directory := "../../../tests/terraform/module/module_with_yor_toggle_off"
+		terraformParser := TerraformParser{}
+		terraformParser.Init(directory, nil)
+		defer terraformParser.Close()
+		blocks, _ := terraformParser.ParseFile(directory + "/main.tf")
+		assert.Equal(t, 1, len(blocks))
+		for _, block := range blocks {
+			assert.False(t, block.IsBlockTaggable(), fmt.Sprintf("Block %v should not be taggable", block.GetResourceID()))
+		}
+	})
 }
 
 func TestExtractProviderFromModuleSrc(t *testing.T) {

--- a/tests/terraform/module/module_with_yor_toggle_off/main.tf
+++ b/tests/terraform/module/module_with_yor_toggle_off/main.tf
@@ -1,0 +1,7 @@
+module "network" {
+  source = "Azure/network/azurerm"
+  tags = {
+    test = "true"
+    yor_toggle = false
+  }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This patch add support for switching yor tagging on/off for modules/resources by adding a `yor_toggle` flag in `tags`.