### PR TITLE
refactor utils code to use generics instead of reflect

### DIFF
--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -197,27 +197,27 @@ func (t *TagGroup) CalculateTagValue(block structure.IBlock, tag Tag) (tags.ITag
 					matching := true
 					for tagName, tagMatch := range matchType["tags"].(map[interface{}]interface{}) {
 						foundTag := false
-						switch tagMatch.(type) {
+						switch tagMatchV := tagMatch.(type) {
 						case string:
 							for _, blockTag := range blockTags {
 								blockTagKey, blockTagValue := blockTag.GetKey(), blockTag.GetValue()
-								if blockTagKey == tagName && blockTagValue == tagMatch {
+								if blockTagKey == tagName && blockTagValue == tagMatchV {
 									foundTag = true
 									break
 								}
 							}
-						case []interface{}:
+						case []string:
 							for _, blockTag := range blockTags {
 								blockTagKey, blockTagValue := blockTag.GetKey(), blockTag.GetValue()
 								if blockTagKey == tagName {
 									if blockTagKey == tags.GitModifiersTagKey {
 										for _, val := range strings.Split(blockTagValue, "/") {
-											if utils.InSlice(tagMatch, val) {
+											if utils.InSlice(tagMatchV, val) {
 												foundTag = true
 												break
 											}
 										}
-									} else if utils.InSlice(tagMatch, blockTagValue) {
+									} else if utils.InSlice(tagMatchV, blockTagValue) {
 										foundTag = true
 										break
 									}

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -18,27 +18,31 @@ import (
 // RemoveGcpInvalidChars Source of regex: https://cloud.google.com/compute/docs/labeling-resources
 var RemoveGcpInvalidChars = regexp.MustCompile(`[^\p{Ll}\p{Lo}\p{N}_-]`)
 
-func InSlice(slice interface{}, elem interface{}) bool {
-	for _, e := range convertToInterfaceSlice(slice) {
-		if getKind(e) != getKind(elem) {
-			continue
-		}
-		if getKind(e) == reflect.Slice {
-			inSlice := true
-			for _, subElem := range convertToInterfaceSlice(elem) {
-				inSlice = inSlice && InSlice(e, subElem)
-				if !inSlice {
-					break
-				}
-			}
-			if inSlice {
-				return true
-			}
-		} else if e == elem {
+func InSlice[T comparable](elems []T, v T) bool {
+	for _, s := range elems {
+		if v == s {
 			return true
 		}
 	}
+	return false
+}
 
+func SliceInSlices[T comparable](elems [][]T, vSlice []T) bool {
+	for _, elemSlice := range elems {
+		curSize := len(elemSlice)
+		if curSize != len(vSlice) {
+			continue
+		}
+		equalNum := 0
+		for i, elem := range elemSlice {
+			if elem == vSlice[i] {
+				equalNum++
+			}
+		}
+		if equalNum == curSize {
+			return true
+		}
+	}
 	return false
 }
 
@@ -55,26 +59,6 @@ func AllNil(vv ...interface{}) bool {
 		}
 	}
 	return true
-}
-
-func getKind(val interface{}) reflect.Kind {
-	s := reflect.ValueOf(val)
-	return s.Kind()
-}
-
-func convertToInterfaceSlice(origin interface{}) []interface{} {
-	s := reflect.ValueOf(origin)
-	if s.Kind() != reflect.Slice {
-		return make([]interface{}, 0)
-	}
-
-	ret := make([]interface{}, s.Len())
-
-	for i := 0; i < s.Len(); i++ {
-		ret[i] = s.Index(i).Interface()
-	}
-
-	return ret
 }
 
 func GetFileScanner(filePath string, nonFoundLines *structure.Lines) (*bufio.Scanner, *structure.Lines) {

--- a/src/common/utils/utils_test.go
+++ b/src/common/utils/utils_test.go
@@ -65,64 +65,67 @@ func TestGetFileFormat(t *testing.T) {
 }
 
 func TestInSlice(t *testing.T) {
-	type args struct {
-		slice interface{}
+	type args[T comparable] struct {
+		slice []T
 		elem  interface{}
 	}
-	tests := []struct {
+	type testStruct[T comparable] struct {
 		name string
-		args args
+		args args[T]
 		want bool
-	}{
+	}
+
+	testsStr := []testStruct[string]{
 		{
 			name: "in slice string",
-			args: args{slice: []string{"a", "b", "c", "e"}, elem: "a"},
+			args: args[string]{slice: []string{"a", "b", "c", "e"}, elem: "a"},
 			want: true,
 		},
 		{
 			name: "not in slice string",
-			args: args{slice: []string{"a", "b", "c", "e"}, elem: "d"},
-			want: false,
-		},
-		{
-			name: "in slice int",
-			args: args{slice: []int{1, 2, 3, 4}, elem: 1},
-			want: true,
-		},
-		{
-			name: "not in slice int",
-			args: args{slice: []int{1, 2, 3, 4}, elem: 5},
-			want: false,
-		},
-		{
-			name: "slice in slice ",
-			args: args{slice: [][]int{{1, 2, 3, 4}, {5, 6}, {7}}, elem: []int{5, 6}},
-			want: true,
-		},
-		{
-			name: "not slice in slice ",
-			args: args{slice: [][]int{{1, 2, 3, 4}, {5, 6}, {7}}, elem: []int{5, 7}},
-			want: false,
-		},
-		{
-			name: "different kinds",
-			args: args{slice: []int{1, 2, 3, 4}, elem: "bana"},
+			args: args[string]{slice: []string{"a", "b", "c", "e"}, elem: "d"},
 			want: false,
 		},
 		{
 			name: "nil slice",
-			args: args{slice: nil, elem: "bana"},
+			args: args[string]{slice: nil, elem: "bana"},
 			want: false,
 		},
+
 		{
 			name: "empty slice",
-			args: args{slice: []int{}, elem: "bana"},
+			args: args[string]{slice: []string{}, elem: "bana"},
 			want: false,
 		},
 	}
-	for _, tt := range tests {
+	testsInt := []testStruct[int]{
+		{
+			name: "in slice int",
+			args: args[int]{slice: []int{1, 2, 3, 4}, elem: 1},
+			want: true,
+		},
+		{
+			name: "not in slice int",
+			args: args[int]{slice: []int{1, 2, 3, 4}, elem: 5},
+			want: false,
+		},
+		//{ // not supported for generics
+		//	name: "different kinds",
+		//	args: args[int]{slice: []int{1, 2, 3, 4}, elem: "bana"},
+		//	want: false,
+		//},
+
+	}
+	for _, tt := range testsStr {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := InSlice(tt.args.slice, tt.args.elem); got != tt.want {
+			if got := InSlice(tt.args.slice, tt.args.elem.(string)); got != tt.want {
+				t.Errorf("InSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	for _, tt := range testsInt {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InSlice(tt.args.slice, tt.args.elem.(int)); got != tt.want {
 				t.Errorf("InSlice() = %v, want %v", got, tt.want)
 			}
 		})
@@ -196,4 +199,33 @@ func TestAllNil(t *testing.T) {
 		i := []interface{}(nil)
 		assert.Equal(t, true, AllNil(i))
 	})
+}
+
+func TestSliceInSlices(t *testing.T) {
+	type args[T comparable] struct {
+		elems  [][]T
+		vSlice []T
+	}
+	type testCase[T comparable] struct {
+		name string
+		args args[T]
+		want bool
+	}
+	tests := []testCase[int]{
+		{
+			name: "slice in slice ",
+			args: args[int]{elems: [][]int{{1, 2, 3, 4}, {5, 6}, {7}}, vSlice: []int{5, 6}},
+			want: true,
+		},
+		{
+			name: "not slice in slice ",
+			args: args[int]{elems: [][]int{{1, 2, 3, 4}, {5, 6}, {7}}, vSlice: []int{5, 7}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, SliceInSlices(tt.args.elems, tt.args.vSlice), "SliceInSlices(%v, %v)", tt.args.elems, tt.args.vSlice)
+		})
+	}
 }

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -52,7 +52,7 @@ func TestTerraformParser_ParseFile(t *testing.T) {
 		for _, block := range parsedBlocks {
 			hclBlock := block.GetRawBlock().(*hclwrite.Block)
 			if hclBlock.Type() == ResourceBlockType {
-				if utils.InSlice(taggableResources, hclBlock.Labels()) {
+				if utils.SliceInSlices(taggableResources, hclBlock.Labels()) {
 					assert.True(t, block.IsBlockTaggable(), fmt.Sprintf("expected block %s to be taggable", hclBlock.Labels()))
 					resourceName := hclBlock.Labels()[1]
 					expectedTagsForResource := expectedTags[resourceName]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Reflect is very costly performance wise. it's better not to use it if you don't have to.
change the functions to use generics which available since go 1.18
