### PR TITLE
Add yor toggle for Terraform by configuring in `variables.tf` 

### DIFF
--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -220,7 +220,7 @@ func (p *CloudformationParser) GetExistingTags(tagsValue reflect.Value) []tags.I
 	return iTags
 }
 
-func (p *CloudformationParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error {
+func (p *CloudformationParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string, addToggle bool) error {
 	for _, block := range blocks {
 		block := block.(*CloudformationBlock)
 		block.UpdateTags()

--- a/src/cloudformation/structure/cloudformation_parser_test.go
+++ b/src/cloudformation/structure/cloudformation_parser_test.go
@@ -183,7 +183,7 @@ func writeCFNTestHelper(t *testing.T, directory string, testFileName string, fil
 	if err != nil {
 		t.Fail()
 	}
-	err = cfnParser.WriteFile(readFilePath, cfnBlocks, f.Name())
+	err = cfnParser.WriteFile(readFilePath, cfnBlocks, f.Name(), false)
 	if err != nil {
 		t.Fail()
 	}

--- a/src/common/parser.go
+++ b/src/common/parser.go
@@ -7,7 +7,7 @@ type IParser interface {
 	Name() string
 	ValidFile(filePath string) bool
 	ParseFile(filePath string) ([]structure.IBlock, error)
-	WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error
+	WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string, addToggle bool) error
 	GetSkippedDirs() []string
 	GetSupportedFileExtensions() []string
 	Close()

--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -215,7 +215,12 @@ func (r *Runner) FindToggle(file string) bool {
 			continue
 		}
 		for _, block := range blocks {
-			if block.(*tfStructure.TerraformBlock).HclSyntaxBlock.Type == tfStructure.VariableBlockType {
+			terraformBlock, isTerraformType := block.(*tfStructure.TerraformBlock)
+			if !isTerraformType {
+				return false
+			}
+
+			if terraformBlock.HclSyntaxBlock.Type == tfStructure.VariableBlockType {
 				if block.GetResourceID() == "yor_toggle" {
 					rawBlock := block.GetRawBlock().(*hclwrite.Block)
 					valueStr := string(rawBlock.Body().GetAttribute("default").Expr().BuildTokens(hclwrite.Tokens{}).Bytes())

--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -2,6 +2,14 @@ package runner
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"plugin"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
 	cfnStructure "github.com/bridgecrewio/yor/src/cloudformation/structure"
 	"github.com/bridgecrewio/yor/src/common"
 	"github.com/bridgecrewio/yor/src/common/clioptions"
@@ -18,13 +26,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
-	"os"
-	"path/filepath"
-	"plugin"
-	"reflect"
-	"strconv"
-	"strings"
-	"sync"
 )
 
 type Runner struct {

--- a/src/common/runner/runner_test.go
+++ b/src/common/runner/runner_test.go
@@ -247,7 +247,7 @@ func TestRunnerInternals(t *testing.T) {
 			Tag:       []string{"test_tag"},
 			Parsers:   []string{"Terraform"},
 		})
-		yorRunner.TagFile(rootDir + "/tomap.tf")
+		yorRunner.TagFile(rootDir+"/tomap.tf", false)
 		if err != nil {
 			t.Error(err)
 		}

--- a/src/common/tagging/tags/tag.go
+++ b/src/common/tagging/tags/tag.go
@@ -16,6 +16,7 @@ const GitModifiersTagKey = "git_modifiers"
 const GitLastModifiedAtTagKey = "git_last_modified_at"
 const GitLastModifiedByTagKey = "git_last_modified_by"
 const GitRepoTagKey = "git_repo"
+const YorToggle = "yor_toggle"
 
 type ITag interface {
 	Init()

--- a/src/serverless/structure/serverless_parser.go
+++ b/src/serverless/structure/serverless_parser.go
@@ -135,7 +135,7 @@ func (p *ServerlessParser) ParseFile(filePath string) ([]structure.IBlock, error
 	return parsedBlocks, nil
 }
 
-func (p *ServerlessParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string) error {
+func (p *ServerlessParser) WriteFile(readFilePath string, blocks []structure.IBlock, writeFilePath string, addToggle bool) error {
 	for _, block := range blocks {
 		block := block.(*ServerlessBlock)
 		block.UpdateTags()

--- a/src/serverless/structure/serverless_parser_test.go
+++ b/src/serverless/structure/serverless_parser_test.go
@@ -66,7 +66,7 @@ func TestServerlessParser_ParseFile(t *testing.T) {
 		assert.NotNil(t, func1Block)
 		assert.NotNil(t, func2Block)
 		f, _ := os.CreateTemp(directory, "serverless.*.yaml")
-		_ = slsParser.WriteFile(slsFilepath, slsBlocks, f.Name())
+		_ = slsParser.WriteFile(slsFilepath, slsBlocks, f.Name(), false)
 
 		expected, _ := os.ReadFile(expectedSlsFilepath)
 		actual, _ := os.ReadFile(f.Name())
@@ -211,7 +211,7 @@ func Test_mapResourcesLineYAML(t *testing.T) {
 			t.Fail()
 		}
 		f, _ := os.CreateTemp(directory, "serverless.*.yaml")
-		err = slsParser.WriteFile(readFilePath, slsBlocks, f.Name())
+		err = slsParser.WriteFile(readFilePath, slsBlocks, f.Name(), false)
 		if err != nil {
 			t.Fail()
 		}

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -31,7 +31,7 @@ var unsupportedTerraformBlocks = []string{
 	"aws_lb_listener_rule",                   // This resource does not support tags, although docs state otherwise.
 	"aws_cloudwatch_log_destination",         // This resource does not support tags, although docs state otherwise.
 	"google_monitoring_notification_channel", //This resource uses labels for other purposes.
-	"aws_secretsmanager_secret_rotation",         // This resource does not support tags, although tfschema states otherwise.
+	"aws_secretsmanager_secret_rotation",     // This resource does not support tags, although tfschema states otherwise.
 }
 
 var taggableResourcesLock sync.RWMutex
@@ -492,6 +492,19 @@ func (p *TerraformParser) parseBlock(hclBlock *hclwrite.Block, filePath string) 
 			}
 		}()
 		isTaggable, existingTags, tagsAttributeName = p.extractTagsFromModule(hclBlock, filePath, isTaggable, existingTags, tagsAttributeName)
+	}
+
+	for _, existingTag := range existingTags {
+		if existingTag.GetKey() == tags.YorToggle {
+			v, err := strconv.ParseBool(existingTag.GetValue())
+			if err != nil {
+				continue
+			}
+
+			if !v {
+				isTaggable = false
+			}
+		}
 	}
 
 	terraformBlock := TerraformBlock{

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -195,7 +195,7 @@ func TestTerraformParser_Module(t *testing.T) {
 			}
 		}
 
-		err = p.WriteFile(filePath, parsedBlocks, writeFilePath)
+		err = p.WriteFile(filePath, parsedBlocks, writeFilePath, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -258,7 +258,7 @@ func TestTerraformParser_Module(t *testing.T) {
 			}
 		}
 
-		err = p.WriteFile(filePath, parsedBlocks, writeFilePath)
+		err = p.WriteFile(filePath, parsedBlocks, writeFilePath, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -312,7 +312,7 @@ func TestTerraformParser_Module(t *testing.T) {
 			}
 		}
 
-		err = p.WriteFile(filePath, parsedBlocks, writeFilePath)
+		err = p.WriteFile(filePath, parsedBlocks, writeFilePath, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -384,7 +384,7 @@ func TestTerraformParser_Module(t *testing.T) {
 		defer func() {
 			_ = os.Remove(resultFileName)
 		}()
-		_ = p.WriteFile(sourceFilePath, blocks, resultFileName)
+		_ = p.WriteFile(sourceFilePath, blocks, resultFileName, false)
 		resultStr, _ := os.ReadFile(resultFileName)
 		expectedStr, _ := os.ReadFile(expectedFileName)
 		assert.Equal(t, string(resultStr), string(expectedStr))
@@ -430,7 +430,7 @@ func TestTerraformParser_Module(t *testing.T) {
 		defer func() {
 			_ = os.Remove(resultFileName)
 		}()
-		_ = p.WriteFile(sourceFilePath, blocks, resultFileName)
+		_ = p.WriteFile(sourceFilePath, blocks, resultFileName, false)
 		resultStr, _ := os.ReadFile(resultFileName)
 		expectedStr, _ := os.ReadFile(expectedFileName)
 		assert.Equal(t, string(expectedStr), string(resultStr))
@@ -454,7 +454,7 @@ func TestTerraformParser_Module(t *testing.T) {
 			}
 		}
 
-		_ = p.WriteFile(filePath, blocks, resultFilePath)
+		_ = p.WriteFile(filePath, blocks, resultFilePath, false)
 		defer func() {
 			_ = os.Remove(resultFilePath)
 		}()

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -498,6 +498,18 @@ func TestTerraformParser_Module(t *testing.T) {
 			assert.True(t, block.IsBlockTaggable(), fmt.Sprintf("Block %v should be taggable", block.GetResourceID()))
 		}
 	})
+
+	t.Run("Test isModuleTaggable with yor_toggle set to false", func(t *testing.T) {
+		directory := "../../../tests/terraform/module/module_with_yor_toggle_off"
+		terraformParser := TerraformParser{}
+		terraformParser.Init(directory, nil)
+		defer terraformParser.Close()
+		blocks, _ := terraformParser.ParseFile(directory + "/main.tf")
+		assert.Equal(t, 1, len(blocks))
+		for _, block := range blocks {
+			assert.False(t, block.IsBlockTaggable(), fmt.Sprintf("Block %v should not be taggable", block.GetResourceID()))
+		}
+	})
 }
 
 func TestExtractProviderFromModuleSrc(t *testing.T) {

--- a/src/terraform/structure/terraform_parser_test.go
+++ b/src/terraform/structure/terraform_parser_test.go
@@ -498,18 +498,6 @@ func TestTerraformParser_Module(t *testing.T) {
 			assert.True(t, block.IsBlockTaggable(), fmt.Sprintf("Block %v should be taggable", block.GetResourceID()))
 		}
 	})
-
-	t.Run("Test isModuleTaggable with yor_toggle set to false", func(t *testing.T) {
-		directory := "../../../tests/terraform/module/module_with_yor_toggle_off"
-		terraformParser := TerraformParser{}
-		terraformParser.Init(directory, nil)
-		defer terraformParser.Close()
-		blocks, _ := terraformParser.ParseFile(directory + "/main.tf")
-		assert.Equal(t, 1, len(blocks))
-		for _, block := range blocks {
-			assert.False(t, block.IsBlockTaggable(), fmt.Sprintf("Block %v should not be taggable", block.GetResourceID()))
-		}
-	})
 }
 
 func TestExtractProviderFromModuleSrc(t *testing.T) {
@@ -537,7 +525,6 @@ func TestExtractProviderFromModuleSrc(t *testing.T) {
 		})
 	}
 }
-
 
 func TestExtractSubdirFromRemoteModuleSrc(t *testing.T) {
 	tests := []struct {

--- a/tests/terraform/module/module_with_yor_toggle_off/main.tf
+++ b/tests/terraform/module/module_with_yor_toggle_off/main.tf
@@ -1,0 +1,7 @@
+module "network" {
+  source = "Azure/network/azurerm"
+  tags = {
+    test = "true"
+    yor_toggle = false
+  }
+}

--- a/tests/terraform/module/module_with_yor_toggle_off/main.tf
+++ b/tests/terraform/module/module_with_yor_toggle_off/main.tf
@@ -1,7 +1,0 @@
-module "network" {
-  source = "Azure/network/azurerm"
-  tags = {
-    test = "true"
-    yor_toggle = false
-  }
-}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

By setting
```
variable "yor_toggle" {
  default = true
}
```

this patch helps to generate a new variable named `turn_off_yor_tags` in `variables.tf` and embed a ternary operator in HCL code for selecting the different sets of tags.