### PR TITLE
Use `logger.Debug` instead of `logger.Error` so yor can continue on file reading error

### DIFF
--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -119,7 +119,7 @@ func (r *Runner) TagDirectory() (*reports.ReportService, error) {
 	var files []string
 	err := filepath.Walk(r.dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			logger.Debug(fmt.Sprintf("Failed to scan dir %s", path))
+			logger.Warning(fmt.Sprintf("Failed to scan dir %s", path))
 		}
 		if !info.IsDir() {
 			files = append(files, path)

--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -119,7 +119,7 @@ func (r *Runner) TagDirectory() (*reports.ReportService, error) {
 	var files []string
 	err := filepath.Walk(r.dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			logger.Error("Failed to scan dir", path)
+			logger.Debug(fmt.Sprintf("Failed to scan dir %s", path))
 		}
 		if !info.IsDir() {
 			files = append(files, path)


### PR DESCRIPTION
Hi folks,

We've met a strange issue, `yor.exe` just refuse tagging my Terraform module, after debugging I found that in `filepath.Walk` callback, once we've met an error on reading a file or directory, we'll invoke `logger.Error`, which leads to [`os.exit(1)`](https://github.com/bridgecrewio/yor/blob/main/src/common/logger/logging_service.go#L72-L81).

That's way too much I think, in my case I have a symlink created in Linux os, on Windows yor would encounter an error when tried to read it, we can just log this error, then continue executing right? So this pr just downgrade the log level to `Warning`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
