### PR TITLE
feat(general): Support conflicted git modifiers custom tag

### DIFF
--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -240,9 +240,14 @@ func (t *TagGroup) CalculateTagValue(block structure.IBlock, tag Tag) (tags.ITag
 				}
 			}
 		}
-		if len(gitModifiersCounts) > 0 {
-			maxMatchValue := utils.MaxMapCountKey(gitModifiersCounts)
-			retTag.Value = evaluateTemplateVariable(maxMatchValue)
+		if len(gitModifiersCounts) == 1 {
+			for k, _ := range gitModifiersCounts {
+				retTag.Value = evaluateTemplateVariable(k)
+				break
+			}
+		} else if len(gitModifiersCounts) > 1 {
+			// TODO use the CODEOWNERS file to resolve the conflict
+			logger.Info(fmt.Sprintf("Git-modifiers conflict found, fallback to default value %s\n", retTag.Value))
 		}
 		return retTag, nil
 	} else if tag.defaultValue != "" {

--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -208,10 +208,10 @@ func (t *TagGroup) CalculateTagValue(block structure.IBlock, tag Tag) (tags.ITag
 								}
 							}
 						case []string, []interface{}:
-							if b, ok := tagMatchV.([]interface{}); ok {
-								tagMatchStrings := make([]string, len(b))
-								for i := range b {
-									tagMatchStrings[i] = b[i].(string)
+							if tagMatchTypeSwitch, ok := tagMatchV.([]interface{}); ok {
+								tagMatchStrings := make([]string, len(tagMatchTypeSwitch))
+								for i := range tagMatchTypeSwitch {
+									tagMatchStrings[i] = tagMatchTypeSwitch[i].(string)
 								}
 
 								for _, blockTag := range blockTags {

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -209,6 +209,89 @@ func TestExternalTagGroup(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("test tagGroup conflicted git_modifiers", func(t *testing.T) {
+		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group.yml")
+		tagGroup := TagGroup{}
+		tagGroup.InitTagGroup("", nil, nil)
+		tagGroup.InitExternalTagGroups(confPath)
+		block := &MockTestBlock{
+			Block: structure.Block{
+				FilePath:   "",
+				IsTaggable: true,
+				ExitingTags: []tags.ITag{
+					&tags.Tag{
+						Key:   "git_modifiers",
+						Value: "tronxd/nofar/rotemavni",
+					},
+					&tags.Tag{
+						Key:   "git_repo",
+						Value: "yor",
+					},
+					&tags.Tag{
+						Key:   "git_commit",
+						Value: "00193660c248483862c06e2ae96111adfcb683af",
+					},
+					&tags.Tag{
+						Key:   "yor_trace",
+						Value: "123",
+					},
+				},
+			},
+		}
+		err := tagGroup.CreateTagsForBlock(block)
+		if err != nil {
+			logger.Warning(err.Error())
+			t.Fail()
+		}
+		for _, newTag := range block.NewTags {
+			if newTag.GetKey() == "team" {
+				assert.Equal(t, "seceng", newTag.GetValue())
+			}
+		}
+	})
+
+	t.Run("test tagGroup non conflicted git_modifiers", func(t *testing.T) {
+		confPath, _ := filepath.Abs("../../../../tests/external_tags/external_tag_group.yml")
+		tagGroup := TagGroup{}
+		tagGroup.InitTagGroup("", nil, nil)
+		tagGroup.InitExternalTagGroups(confPath)
+		block := &MockTestBlock{
+			Block: structure.Block{
+				FilePath:   "",
+				IsTaggable: true,
+				ExitingTags: []tags.ITag{
+					&tags.Tag{
+						Key:   "git_modifiers",
+						Value: "nofar",
+					},
+					&tags.Tag{
+						Key:   "git_repo",
+						Value: "yor",
+					},
+					&tags.Tag{
+						Key:   "git_commit",
+						Value: "00193660c248483862c06e2ae96111adfcb683af",
+					},
+					&tags.Tag{
+						Key:   "yor_trace",
+						Value: "123",
+					},
+				},
+			},
+		}
+		err := tagGroup.CreateTagsForBlock(block)
+		if err != nil {
+			logger.Warning(err.Error())
+			t.Fail()
+		}
+		for _, newTag := range block.NewTags {
+			if newTag.GetKey() == "team" {
+				assert.Equal(t, "platform", newTag.GetValue())
+			}
+		}
+	})
+
 }
 
 type MockTestBlock struct {

--- a/src/common/tagging/external/tag_group_test.go
+++ b/src/common/tagging/external/tag_group_test.go
@@ -246,7 +246,7 @@ func TestExternalTagGroup(t *testing.T) {
 		}
 		for _, newTag := range block.NewTags {
 			if newTag.GetKey() == "team" {
-				assert.Equal(t, "seceng", newTag.GetValue())
+				assert.Equal(t, "interfaces", newTag.GetValue())
 			}
 		}
 	})

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -166,3 +166,15 @@ func GetEnv(key, fallback string) string {
 	}
 	return fallback
 }
+
+func MaxMapCountKey(m map[string]int) string {
+	var maxKey string
+	var maxCount = -1
+	for key, count := range m {
+		if count > maxCount {
+			maxKey = key
+			maxCount = count
+		}
+	}
+	return maxKey
+}


### PR DESCRIPTION
- Support the option of multiple git modifiers (delimited by `/`) when using external custom tags
- In case of a conflict between multiple tag values for the git_modifiers, fallback to the default value
- Fix type switching issue which caused external tags to not work properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
