### PR TITLE
Fix unable to parse each.value object issue

### DIFF
--- a/src/terraform/structure/terraform_block.go
+++ b/src/terraform/structure/terraform_block.go
@@ -21,6 +21,7 @@ const DataBlockType = "data"
 const LocalBlockType = "local"
 const VarBlockType = "var"
 const VariableBlockType = "variable"
+const EachBlockType = "each"
 
 var SupportedBlockTypes = []string{ResourceBlockType, ModuleBlockType, VariableBlockType}
 

--- a/src/terraform/structure/terraform_parser.go
+++ b/src/terraform/structure/terraform_parser.go
@@ -287,7 +287,7 @@ func (p *TerraformParser) modifyBlockTags(rawBlock *hclwrite.Block, parsedBlock 
 				isMergeOpExists = true
 				break
 			}
-			if i == 0 && utils.InSlice([]string{VarBlockType, LocalBlockType, ModuleBlockType, DataBlockType}, tokenStr) {
+			if i == 0 && utils.InSlice([]string{VarBlockType, LocalBlockType, ModuleBlockType, DataBlockType, EachBlockType}, tokenStr) {
 				isRenderedAttribute = true
 				break
 			}

--- a/tests/terraform/resources/for_each/main.tf
+++ b/tests/terraform/resources/for_each/main.tf
@@ -1,0 +1,20 @@
+locals {
+  subnets = {
+    "us-east-1" = {
+      cidr_block = "10.10.10.10/24"
+      tags       = {
+        location = "us-east-1a"
+      }
+    }
+  }
+}
+
+resource "aws_subnet" "eks_subnet" {
+  for_each = local.subnets
+
+  vpc_id                  = var.vpc_id
+  cidr_block              = each.value.cidr_block
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+  tags                    = each.value.tags
+}

--- a/tests/terraform/resources/for_each/main.tf
+++ b/tests/terraform/resources/for_each/main.tf
@@ -14,7 +14,7 @@ resource "aws_subnet" "eks_subnet" {
 
   vpc_id                  = var.vpc_id
   cidr_block              = each.value.cidr_block
-  availability_zone       = var.availability_zone
+  availability_zone       = each.key
   map_public_ip_on_launch = true
   tags                    = each.value.tags
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Currently yor cannot parse existing tags like `tags = each.value.tags`. This pr fix this issue.