### PR TITLE
Fix skip-dir issue on windows

### DIFF
--- a/src/common/runner/runner.go
+++ b/src/common/runner/runner.go
@@ -286,7 +286,7 @@ func extractExternalResources(plug *plugin.Plugin, symbol string) ([]interface{}
 func (r *Runner) isFileSkipped(p common.IParser, file string) bool {
 	relPath, _ := filepath.Rel(r.dir, file)
 	for _, sp := range r.skipDirs {
-		if strings.HasPrefix(r.dir+"/"+relPath, sp) {
+		if strings.HasPrefix(filepath.Join(r.dir, relPath), sp) {
 			return true
 		}
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This pr should fix #360 by using `filepath.Join` to join file paths instead of using `/`.