### PR TITLE
Add check mode for yor tag command

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func tagCommand() *cli.Command {
 	skipResourcesArg := "skip-resources"
 	parsersArgs := "parsers"
 	dryRunArgs := "dry-run"
+	checkModeArgs := "check"
 	tagLocalModules := "tag-local-modules"
 	tagPrefix := "tag-prefix"
 	noColor := "no-color"
@@ -113,6 +114,7 @@ func tagCommand() *cli.Command {
 				SkipResources:     c.StringSlice(skipResourcesArg),
 				Parsers:           c.StringSlice(parsersArgs),
 				DryRun:            c.Bool(dryRunArgs),
+				CheckMode:         c.Bool(checkModeArgs),
 				TagLocalModules:   c.Bool(tagLocalModules),
 				TagPrefix:         c.String(tagPrefix),
 				NoColor:           c.Bool(noColor),
@@ -208,6 +210,12 @@ func tagCommand() *cli.Command {
 				DefaultText: "false",
 			},
 			&cli.BoolFlag{
+				Name:        checkModeArgs,
+				Usage:       "exit with error if changes made/needed",
+				Value:       false,
+				DefaultText: "false",
+			},
+			&cli.BoolFlag{
 				Name:        tagLocalModules,
 				Usage:       "Always tag local modules",
 				Value:       false,
@@ -263,6 +271,9 @@ func tag(options *clioptions.TagOptions, colors *common.ColorStruct) error {
 	}
 	printReport(reportService, options, colors)
 
+	if options.CheckMode && reportService.Changed() {
+		logger.Error("Changes needed and CheckMode is true.")
+	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func tagCommand() *cli.Command {
 	skipResourcesArg := "skip-resources"
 	parsersArgs := "parsers"
 	dryRunArgs := "dry-run"
-	checkModeArgs := "check"
+	validateModeArgs := "validate"
 	tagLocalModules := "tag-local-modules"
 	tagPrefix := "tag-prefix"
 	noColor := "no-color"
@@ -114,7 +114,7 @@ func tagCommand() *cli.Command {
 				SkipResources:     c.StringSlice(skipResourcesArg),
 				Parsers:           c.StringSlice(parsersArgs),
 				DryRun:            c.Bool(dryRunArgs),
-				CheckMode:         c.Bool(checkModeArgs),
+				ValidateMode:      c.Bool(validateModeArgs),
 				TagLocalModules:   c.Bool(tagLocalModules),
 				TagPrefix:         c.String(tagPrefix),
 				NoColor:           c.Bool(noColor),
@@ -210,8 +210,8 @@ func tagCommand() *cli.Command {
 				DefaultText: "false",
 			},
 			&cli.BoolFlag{
-				Name:        checkModeArgs,
-				Usage:       "exit with error if changes made/needed",
+				Name:        validateModeArgs,
+				Usage:       "dry-run and exit with error if changes made/needed",
 				Value:       false,
 				DefaultText: "false",
 			},
@@ -260,6 +260,9 @@ func listTags(options *clioptions.ListTagsOptions) error {
 
 func tag(options *clioptions.TagOptions, colors *common.ColorStruct) error {
 	yorRunner := new(runner.Runner)
+	if options.ValidateMode {
+		options.DryRun = true
+	}
 	logger.Info(fmt.Sprintf("Setting up to tag the directory %v\n", options.Directory))
 	err := yorRunner.Init(options)
 	if err != nil {
@@ -271,8 +274,8 @@ func tag(options *clioptions.TagOptions, colors *common.ColorStruct) error {
 	}
 	printReport(reportService, options, colors)
 
-	if options.CheckMode && reportService.Changed() {
-		logger.Error("Changes needed and CheckMode is true.")
+	if options.ValidateMode && reportService.Changed() {
+		logger.Error("Changes needed and ValidateMode is true.")
 	}
 	return nil
 }

--- a/src/common/clioptions/cli.go
+++ b/src/common/clioptions/cli.go
@@ -28,7 +28,7 @@ type TagOptions struct {
 	SkipResources     []string
 	Parsers           []string
 	DryRun            bool
-	CheckMode         bool
+	ValidateMode      bool
 	TagLocalModules   bool
 	TagPrefix         string
 	NoColor           bool

--- a/src/common/clioptions/cli.go
+++ b/src/common/clioptions/cli.go
@@ -28,6 +28,7 @@ type TagOptions struct {
 	SkipResources     []string
 	Parsers           []string
 	DryRun            bool
+	CheckMode         bool
 	TagLocalModules   bool
 	TagPrefix         string
 	NoColor           bool

--- a/src/common/reports/report_service.go
+++ b/src/common/reports/report_service.go
@@ -51,6 +51,14 @@ func init() {
 	ReportServiceInst = &ReportService{}
 }
 
+func (r *ReportService) Changed() bool {
+	changesAccumulator := TagChangeAccumulatorInstance
+	new_count := len(changesAccumulator.NewBlockTraces)
+	updated_count := len(changesAccumulator.UpdatedBlockTraces)
+
+	return new_count > 0 || updated_count > 0
+}
+
 func (r *ReportService) GetReport() *Report {
 	return &r.report
 }

--- a/src/common/reports/results_test.go
+++ b/src/common/reports/results_test.go
@@ -29,6 +29,10 @@ func TestResultsGeneration(t *testing.T) {
 		assert.Equal(t, 2, len(updatedBlocks))
 	})
 
+	t.Run("Test changed boolean function", func(t *testing.T) {
+		assert.Equal(t, true, ReportServiceInst.Changed())
+	})
+
 	t.Run("Test report JSON stdout", func(t *testing.T) {
 		ReportServiceInst.CreateReport()
 		_, _ = ReportServiceInst.report.AsJSONBytes()


### PR DESCRIPTION
This commit adds a "check" mode to the tag command, which causes yor to exit with a non-zero status (by calling log.Error()) if any changes were (or would have been, if in dry mode) made.

This is useful in CI pipelines, where one wants to confirm that everything is tagged appropriately.  Check mode is simpler to use in CI than parsing the CLI output.

The check for changes is made after the report is printed, as knowing what was/would-have-been changed is useful in debugging CI failures.

This commit:

- adds a utility method to the report service which returns a boolean value if there were any additions or changes to the tags;
- uses that utility method in the tag command; and
- adds a single simple test for the utility function.

Quibbles:

- It would be nice to be able to test the utility function in a scenario with no changes, but there does not seem to be a test helper to generate that scenario.
- There is no test for the CLI option handling, I'm not clear on how the CLI is tested.
- It might be useful to add a Quiet flag, which suppresses all output. This seems like an orthogonal addition, not part of this MR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
