### PR TITLE
Revert go-git vulnerability

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           filename: coverage.out
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@5cb319c3f99ad1844621d710b413b1727941e62b  # v17
+        uses: tj-actions/verify-changed-files@7f1b21ceb7ef533b97b46e89e2f882ee5cb17ae0  # v16
         id: verify-changed-files
         with:
           files: README.md


### PR DESCRIPTION
This reverts commit 7bf3c5a0ae917982483ddd0cb8592cdf532aba26.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
