### PR TITLE
fix gcp with perfix

### DIFF
--- a/src/common/tagging/gittag/git_tag_group.go
+++ b/src/common/tagging/gittag/git_tag_group.go
@@ -208,7 +208,11 @@ func (t *TagGroup) hasNonTagChanges(blame *gitservice.GitBlame, block structure.
 
 func (t *TagGroup) cleanGCPTagValue(val tags.ITag) {
 	updated := val.GetValue()
-	switch val.GetKey() {
+	keyValue := val.GetKey()
+	if t.Options.TagPrefix != "" {
+		keyValue = strings.TrimPrefix(keyValue, t.Options.TagPrefix)
+	}
+	switch keyValue {
 	case tags.GitModifiersTagKey:
 		modifiers := strings.Split(updated, "/")
 		for i, m := range modifiers {

--- a/src/common/tagging/gittag/git_tag_group_test.go
+++ b/src/common/tagging/gittag/git_tag_group_test.go
@@ -107,6 +107,14 @@ func TestGitTagGroupWithPrefix(t *testing.T) {
 		assert.True(t, strings.HasPrefix(tag.GetKey(), "prefix_"))
 	}
 }
+func TestCleanGCPTagValueWithTagPrefix(t *testing.T) {
+	tagGroup := TagGroup{}
+	tagGroup.Options.TagPrefix = "prefix_"
+	tag := &tags.Tag{Key: "prefix_" + tags.GitFileTagKey, Value: "test/to/path"}
+	tagGroup.cleanGCPTagValue(tag)
+	assert.Equal(t, "test__to__path", tag.GetValue())
+
+}
 
 var ExpectedFileMappingTagged = map[string]map[int]int{
 	"originToGit": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: -1, 7: -1, 8: -1, 9: -1, 10: -1, 11: -1, 12: -1, 13: -1, 14: -1, 15: -1, 16: 6, 17: 7, 18: 8, 19: 9, 20: 10, 21: 11, 22: 12},


### PR DESCRIPTION
Problem description:
Yor already handles fixing of certain label values based on the GCP constraints. Like '/' gets converted to '__' for git_file label value. But if yor argument tag-prefix is specified, this handling does not work.

Solution description:
Checking whether there is a prefix in the tags and appropriate treatment

fixes:https://github.com/bridgecrewio/yor/issues/444