### PR TITLE
Fix Environment variable exfiltration

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,13 @@ yor tag --tag-groups simple --directory terraform/dev/
 # Perform a dry run to get a preview in the CLI output of all of the tags that will be added using Yor without applying any changes to your IaC files.
 yor tag -d . --dry-run
 
-# Use an external tag group configuration file path
+# Use an external tag group configuration file path.
+# SECURITY: do not point --config-file at a path inside the directory passed
+# to -d when the run will auto-commit (e.g. via the bridgecrewio/yor-action
+# GitHub Action). The config file supports ${env:NAME} expansion, so an
+# attacker who can edit a repo-resident config can exfiltrate CI secrets
+# into your IaC files. See docs/3.Custom Taggers/Custom_tagger_YAML.md
+# ("Security considerations for --config-file") for the full guidance.
 yor tag -d . --config-file /path/to/conf/file/
 
 # Apply tags to all resources except of a specified type

--- a/docs/3.Custom Taggers/Custom_tagger_YAML.md
+++ b/docs/3.Custom Taggers/Custom_tagger_YAML.md
@@ -133,3 +133,77 @@ Use the following example to run Yor with custom tags:
 ./yor tag --custom-tagging tests/yor_plugins/example,tests/yor_plugins/tag_group_example
 # run yor with custom tags located in tests/yor_plugins/example and custom taggers located in tests/yor_plugins/tag_group_example
 ```
+
+## Security considerations for `--config-file`
+
+The file you pass to `--config-file` is **trusted input**: Yor reads tag
+names, default values, and match values from it and writes them directly into
+your IaC files. Treat the config file with the same care you treat your
+CI/CD pipeline definitions.
+
+### Do not point `--config-file` at an untrusted or repo-resident path
+
+Storing the config file inside the same directory you scan with `-d` (a
+common pattern — the config lives next to the IaC it tags) is convenient,
+but it means **anyone who can open a pull request can edit the tagging
+rules**. In particular, the config supports a `${env:NAME}` template syntax
+that Yor expands by reading the named environment variable from the runner
+and writing the expanded value as a tag. If the runner has CI secrets in
+scope (the standard GitHub Action setup, including the
+`pull_request_target` trigger), an attacker can reference a secret variable
+from the config and have Yor copy that secret value into your IaC files —
+which the [official `bridgecrewio/yor-action`](https://github.com/bridgecrewio/yor-action)
+then commits and pushes back to the repository, persisting the leak to git
+history.
+
+**Recommended layouts:**
+
+| Layout | Safe? |
+| --- | --- |
+| `--config-file` lives **outside** the directory passed to `-d` (e.g. checked into a separate, protected repo or assembled from CI variables at runtime) | ✅ Yes |
+| `--config-file` lives **inside** `-d`, but the action runs with `commit_changes: 'NO'` (Yor only reports, never pushes) | ✅ Yes |
+| `--config-file` lives **inside** `-d` and the action auto-commits | ❌ **Avoid** — a PR author can edit the config to leak environment variables |
+
+Since version `<TODO release>`, Yor enforces two defense layers automatically:
+
+### Layer 1 — env-var expansion is restricted to an allowlist
+
+In `${env:NAME}` template values, only the following environment variable
+names are expanded by default:
+
+- Any name starting with `YOR_` (e.g. `YOR_OWNER`, `YOR_SIMPLE_TAGS`).
+- The exact name `GIT_BRANCH` (preserved for backward compatibility with
+  documented usage).
+
+Every other name is left **literally unsubstituted** — Yor writes the raw
+string `${env:NAME}` into the tag rather than the secret's value, and emits
+a warning to the log. Well-known credential variables (`GITHUB_TOKEN`,
+`GH_TOKEN`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+`AWS_SESSION_TOKEN`, `GOOGLE_APPLICATION_CREDENTIALS`,
+`AZURE_CLIENT_SECRET`, `NPM_TOKEN`, `SLACK_TOKEN`) and any name containing
+`SECRET`, `PASSWORD`, `PASSWD`, `PRIVATE_KEY`, `APIKEY`, `API_KEY`, or
+`CREDENTIAL` are **always denied**, even if explicitly allowlisted.
+
+Two environment variables tune this behavior:
+
+- `YOR_ENV_ALLOWLIST` — comma-separated list of additional names (or
+  `PREFIX*` globs) that operators can allow. Example:
+  `YOR_ENV_ALLOWLIST=DEPLOY_REGION,MYORG_*`. The hard denylist above always
+  wins, so this cannot be used to re-enable secret expansion.
+- `YOR_DISABLE_ENV_EXPANSION=1` — global kill switch that disables
+  `${env:...}` expansion entirely. Use this in hardened environments where
+  no template expansion is needed.
+
+### Layer 2 — the GitHub Action refuses to commit a repo-resident config
+
+The official [`bridgecrewio/yor-action`](https://github.com/bridgecrewio/yor-action)
+entrypoint refuses to auto-commit when `--config-file` resolves to a path
+inside the directory passed to `-d`. In that case it emits a GitHub Actions
+error annotation and exits with code `2`, so the workflow check fails and
+nothing is pushed. To opt out, either:
+
+- move the config file outside the scanned directory, or
+- set the action input `commit_changes: 'NO'`.
+
+This guard is purely a deployment-layer safeguard; running the Yor binary
+directly (e.g. as a pre-commit hook or locally) is unaffected.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,8 +33,31 @@ _git_is_dirty() {
     [ -n "$(git status -s --untracked-files=no)" ]
 }
 
+# F-001 mitigation: refuse to auto-commit when the external tag-group config
+# file lives inside the scanned directory. Such layouts let any contributor
+# turn a config edit into arbitrary tag content (including expanded env
+# values) that is then pushed back to the repo by this entrypoint, persisting
+# the leak to git history. The Yor binary itself already restricts which env
+# vars can be expanded; this is a second, deployment-layer guard.
+_config_file_inside_scanned_dir() {
+  [[ -z "$INPUT_CONFIG_FILE" || -z "$INPUT_DIRECTORY" ]] && return 1
+  local cfg dir
+  cfg=$(cd "$(dirname "$INPUT_CONFIG_FILE")" 2>/dev/null && pwd)/$(basename "$INPUT_CONFIG_FILE")
+  dir=$(cd "$INPUT_DIRECTORY" 2>/dev/null && pwd)
+  [[ -z "$cfg" || -z "$dir" ]] && return 1
+  # Append a trailing slash so /repo/foo does not match /repo/foobar.
+  [[ "$cfg" == "$dir"/* ]]
+}
+
 if [[ $YOR_EXIT_CODE -eq 0 && $INPUT_COMMIT_CHANGES == "YES" ]]
 then
+  if _config_file_inside_scanned_dir
+  then
+    echo "::error::Refusing to auto-commit: --config-file ($INPUT_CONFIG_FILE) is inside the scanned directory ($INPUT_DIRECTORY)."
+    echo "::error::This layout enables F-001 (env-var exfiltration via \${env:...} in the config file)."
+    echo "::error::Move the config file outside the scanned directory, or set commit_changes: 'NO'."
+    exit 2
+  fi
   if _git_is_dirty
   then
     echo "Yor made changes, committing"

--- a/src/cloudformation/structure/cloudformation_parser.go
+++ b/src/cloudformation/structure/cloudformation_parser.go
@@ -132,7 +132,7 @@ func (p *CloudformationParser) ParseFile(filePath string) ([]structure.IBlock, e
 	}
 
 	resourceNames := make([]string, 0)
-	if template.Resources != nil && len(template.Resources) > 0 {
+	if len(template.Resources) > 0 {
 		for resourceName := range template.Resources {
 			resourceNames = append(resourceNames, resourceName)
 		}

--- a/src/common/tagging/external/env_expansion_test.go
+++ b/src/common/tagging/external/env_expansion_test.go
@@ -1,0 +1,175 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEvaluateTemplateVariable_F001 covers the F-001 hardening of the
+// ${env:NAME} expansion performed against values loaded from --config-file.
+//
+// Background: an attacker who can edit the external tag-group config file
+// (commonly committed alongside the IaC it tags) could previously reference
+// arbitrary environment variables — including CI secrets — and have Yor write
+// the expanded value into the IaC files (which are then committed and pushed
+// by entrypoint.sh in the GitHub Action default flow).
+//
+// The hardening introduces a strict allowlist (built-in + opt-in via
+// YOR_ENV_ALLOWLIST), a hard denylist for well-known secret-bearing names,
+// and a global kill switch (YOR_DISABLE_ENV_EXPANSION).
+func TestEvaluateTemplateVariable_F001(t *testing.T) {
+	t.Run("backward-compatible: GIT_BRANCH is allowed by default", func(t *testing.T) {
+		t.Setenv("GIT_BRANCH", "main")
+		assert.Equal(t, "main", evaluateTemplateVariable("${env:GIT_BRANCH}"))
+	})
+
+	t.Run("backward-compatible: YOR_-prefixed names are allowed by default", func(t *testing.T) {
+		t.Setenv("YOR_OWNER", "platform-team")
+		assert.Equal(t, "platform-team", evaluateTemplateVariable("${env:YOR_OWNER}"))
+	})
+
+	t.Run("non-allowlisted name is NOT expanded (literal returned)", func(t *testing.T) {
+		// This is the exact F-001 attack pattern: an arbitrary CI secret
+		// referenced from an attacker-controlled config file. Yor must leave
+		// the placeholder verbatim rather than substitute the secret.
+		t.Setenv("CI_RANDOM_CONFIG", "some-value")
+		got := evaluateTemplateVariable("${env:CI_RANDOM_CONFIG}")
+		assert.Equal(t, "${env:CI_RANDOM_CONFIG}", got,
+			"non-allowlisted env vars must not be substituted into IaC tags")
+	})
+
+	t.Run("GITHUB_TOKEN is denied even if explicitly added to allowlist", func(t *testing.T) {
+		// Demonstrates that the denylist wins over the allowlist — operator
+		// misconfiguration cannot re-open F-001 for well-known secrets.
+		t.Setenv("GITHUB_TOKEN", "ghp_supersecret_token_value")
+		t.Setenv("YOR_ENV_ALLOWLIST", "GITHUB_TOKEN")
+		got := evaluateTemplateVariable("${env:GITHUB_TOKEN}")
+		assert.Equal(t, "${env:GITHUB_TOKEN}", got)
+		assert.NotContains(t, got, "ghp_supersecret_token_value")
+	})
+
+	t.Run("AWS credentials are denied", func(t *testing.T) {
+		for _, name := range []string{
+			"AWS_SECRET_ACCESS_KEY",
+			"AWS_SESSION_TOKEN",
+			"AWS_ACCESS_KEY_ID",
+		} {
+			t.Setenv(name, "AKIAIOSFODNN7EXAMPLE")
+			t.Setenv("YOR_ENV_ALLOWLIST", name)
+			got := evaluateTemplateVariable("${env:" + name + "}")
+			assert.Equal(t, "${env:"+name+"}", got, "must not expand %s", name)
+		}
+	})
+
+	t.Run("substring denylist catches credential-bearing custom names", func(t *testing.T) {
+		// Operator tries to allowlist a custom var whose name looks credential-
+		// bearing — denylist substrings (SECRET, PASSWORD, ...) reject it.
+		for _, name := range []string{
+			"MY_API_SECRET",
+			"DEPLOY_PASSWORD",
+			"DB_PASSWD",
+			"SERVICE_PRIVATE_KEY",
+			"VAULT_APIKEY",
+			"OAUTH_API_KEY",
+			"VENDOR_CREDENTIAL",
+		} {
+			t.Setenv(name, "leaked-value-"+name)
+			t.Setenv("YOR_ENV_ALLOWLIST", name)
+			got := evaluateTemplateVariable("${env:" + name + "}")
+			assert.Equal(t, "${env:"+name+"}", got, "denylist substring should reject %s", name)
+		}
+	})
+
+	t.Run("YOR_ENV_ALLOWLIST extends the allowlist for benign names", func(t *testing.T) {
+		t.Setenv("DEPLOY_REGION", "us-east-1")
+		t.Setenv("YOR_ENV_ALLOWLIST", "DEPLOY_REGION,SOME_OTHER")
+		assert.Equal(t, "us-east-1", evaluateTemplateVariable("${env:DEPLOY_REGION}"))
+	})
+
+	t.Run("YOR_ENV_ALLOWLIST supports prefix glob form", func(t *testing.T) {
+		t.Setenv("MYORG_ENV", "prod")
+		t.Setenv("YOR_ENV_ALLOWLIST", "MYORG_*")
+		assert.Equal(t, "prod", evaluateTemplateVariable("${env:MYORG_ENV}"))
+	})
+
+	t.Run("kill switch disables all expansion, including allowlisted names", func(t *testing.T) {
+		t.Setenv("GIT_BRANCH", "main")
+		t.Setenv("YOR_DISABLE_ENV_EXPANSION", "1")
+		assert.Equal(t, "${env:GIT_BRANCH}", evaluateTemplateVariable("${env:GIT_BRANCH}"))
+	})
+
+	t.Run("non-template input is returned unchanged", func(t *testing.T) {
+		assert.Equal(t, "literal-value", evaluateTemplateVariable("literal-value"))
+	})
+
+	t.Run("missing allowlisted var returns the literal placeholder (no panic)", func(t *testing.T) {
+		// Ensure we don't substitute an empty string when the allowlisted var
+		// happens to be unset — leaving the placeholder is the safer behavior
+		// and matches the pre-existing semantics for missing vars.
+		_ = "GIT_BRANCH" // documented allowlisted name
+		// Deliberately do NOT set GIT_BRANCH for this subtest scope — but
+		// other subtests run in the same process; use a unique allowlisted
+		// name we control instead.
+		t.Setenv("YOR_ENV_ALLOWLIST", "YOR_F001_UNSET_PROBE")
+		got := evaluateTemplateVariable("${env:YOR_F001_UNSET_PROBE}")
+		assert.Equal(t, "${env:YOR_F001_UNSET_PROBE}", got)
+	})
+}
+
+func TestIsEnvVarExpansionAllowed(t *testing.T) {
+	cases := []struct {
+		name    string
+		envName string
+		setup   func(t *testing.T)
+		allowed bool
+	}{
+		{"GIT_BRANCH allowed", "GIT_BRANCH", nil, true},
+		{"YOR_ prefix allowed", "YOR_FOO", nil, true},
+		{"unrelated name denied", "PATH", nil, false},
+		{"GITHUB_TOKEN always denied", "GITHUB_TOKEN", nil, false},
+		{"denylist substring SECRET", "MY_SECRET_X", nil, false},
+		{"denylist substring PASSWORD", "ADMIN_PASSWORD", nil, false},
+		{
+			"allowlist extension via env",
+			"DEPLOY_REGION",
+			func(t *testing.T) { t.Setenv("YOR_ENV_ALLOWLIST", "DEPLOY_REGION") },
+			true,
+		},
+		{
+			"allowlist extension cannot bypass denylist",
+			"GITHUB_TOKEN",
+			func(t *testing.T) { t.Setenv("YOR_ENV_ALLOWLIST", "GITHUB_TOKEN") },
+			false,
+		},
+		{
+			"allowlist glob matches",
+			"ACME_FOO",
+			func(t *testing.T) { t.Setenv("YOR_ENV_ALLOWLIST", "ACME_*") },
+			true,
+		},
+		{
+			"allowlist glob still subject to denylist",
+			"ACME_SECRET",
+			func(t *testing.T) { t.Setenv("YOR_ENV_ALLOWLIST", "ACME_*") },
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+			assert.Equal(t, tc.allowed, isEnvVarExpansionAllowed(tc.envName))
+		})
+	}
+}
+
+func TestIsTruthy(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "Yes", "on", " on "} {
+		assert.True(t, isTruthy(v), "expected truthy: %q", v)
+	}
+	for _, v := range []string{"", "0", "false", "no", "off", "maybe"} {
+		assert.False(t, isTruthy(v), "expected falsy: %q", v)
+	}
+}

--- a/src/common/tagging/external/tag_group.go
+++ b/src/common/tagging/external/tag_group.go
@@ -18,6 +18,58 @@ import (
 
 var EnvVariableRegex = regexp.MustCompile(`\${env:([^\s]+)}`)
 
+// envExpansionAllowedPrefixes is the default allowlist of environment variable
+// name prefixes that may be expanded via the ${env:NAME} template syntax inside
+// the external tag-group config file (see --config-file).
+//
+// SECURITY (F-001): Without this restriction, anyone who can edit the config
+// file (commonly versioned alongside the IaC it tags) can read arbitrary
+// environment variables — including CI secrets such as GITHUB_TOKEN or
+// AWS_SECRET_ACCESS_KEY — by referencing them with ${env:...}. Yor then writes
+// the expanded value as a tag into the IaC files; in the GitHub Action default
+// flow those files are subsequently committed and pushed, persisting the
+// secret to git history.
+//
+// The allowlist intentionally covers only:
+//   - YOR_*        : namespace explicitly reserved for Yor user inputs
+//   - GIT_BRANCH   : preserved for backward compatibility with documented usage
+//
+// Operators that need to expand additional variables can extend the list at
+// runtime via the YOR_ENV_ALLOWLIST environment variable (comma-separated
+// names or `prefix*` globs). Expansion can be disabled entirely with
+// YOR_DISABLE_ENV_EXPANSION=1.
+var envExpansionAllowedPrefixes = []string{"YOR_"}
+var envExpansionAllowedExact = []string{"GIT_BRANCH"}
+
+// envExpansionDenylist contains environment variable name patterns that are
+// NEVER expanded, even if explicitly added to YOR_ENV_ALLOWLIST. This guards
+// against operator misconfiguration that would re-open F-001.
+var envExpansionDenylist = []string{
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_SESSION_TOKEN",
+	"AWS_ACCESS_KEY_ID",
+	"GOOGLE_APPLICATION_CREDENTIALS",
+	"AZURE_CLIENT_SECRET",
+	"NPM_TOKEN",
+	"SLACK_TOKEN",
+}
+
+// envExpansionDenySubstrings rejects any variable whose name contains one of
+// these substrings (case-insensitive). It is a coarse heuristic intended to
+// catch obvious credential-bearing names that an operator might accidentally
+// add to the allowlist (e.g. MY_API_SECRET, CUSTOM_PASSWORD).
+var envExpansionDenySubstrings = []string{
+	"SECRET",
+	"PASSWORD",
+	"PASSWD",
+	"PRIVATE_KEY",
+	"APIKEY",
+	"API_KEY",
+	"CREDENTIAL",
+}
+
 type TagGroup struct {
 	tagging.TagGroup
 	configFilePath  string
@@ -295,15 +347,90 @@ func (t *TagGroup) ExtractExternalGroupsTags(tagsConfig TagsConfig) []Tag {
 
 func evaluateTemplateVariable(val string) string {
 	envVariableMatch := EnvVariableRegex.FindStringSubmatch(val)
-	if len(envVariableMatch) == 2 {
-		envVal, exists := os.LookupEnv(envVariableMatch[1])
-		if !exists {
-			logger.Warning(fmt.Sprintf("environment variable %s is not found", envVariableMatch[1]))
-		} else {
-			return envVal
+	if len(envVariableMatch) != 2 {
+		return val
+	}
+	name := envVariableMatch[1]
+
+	// Kill switch: operators in hardened environments can disable expansion
+	// entirely without redeploying.
+	if isTruthy(os.Getenv("YOR_DISABLE_ENV_EXPANSION")) {
+		logger.Warning(fmt.Sprintf("environment variable expansion is disabled (YOR_DISABLE_ENV_EXPANSION); leaving ${env:%s} untouched", name))
+		return val
+	}
+
+	if !isEnvVarExpansionAllowed(name) {
+		logger.Warning(fmt.Sprintf("refusing to expand ${env:%s}: variable name is not in the Yor env-expansion allowlist (see YOR_ENV_ALLOWLIST). This guard prevents an attacker who controls --config-file from exfiltrating CI secrets.", name))
+		return val
+	}
+
+	envVal, exists := os.LookupEnv(name)
+	if !exists {
+		logger.Warning(fmt.Sprintf("environment variable %s is not found", name))
+		return val
+	}
+	return envVal
+}
+
+// isEnvVarExpansionAllowed reports whether the given environment variable name
+// may be expanded inside an external tag-group config file. The denylist always
+// wins over the allowlist.
+func isEnvVarExpansionAllowed(name string) bool {
+	upper := strings.ToUpper(name)
+
+	// Denylist (always rejected, regardless of operator-supplied allowlist).
+	for _, denied := range envExpansionDenylist {
+		if upper == denied {
+			return false
 		}
 	}
-	return val
+	for _, sub := range envExpansionDenySubstrings {
+		if strings.Contains(upper, sub) {
+			return false
+		}
+	}
+
+	// Built-in allowlist.
+	for _, exact := range envExpansionAllowedExact {
+		if name == exact {
+			return true
+		}
+	}
+	for _, prefix := range envExpansionAllowedPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	// Operator-supplied extension via YOR_ENV_ALLOWLIST.
+	if extra := os.Getenv("YOR_ENV_ALLOWLIST"); extra != "" {
+		for _, entry := range strings.Split(extra, ",") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			// Support `PREFIX*` glob form.
+			if strings.HasSuffix(entry, "*") {
+				if strings.HasPrefix(name, strings.TrimSuffix(entry, "*")) {
+					return true
+				}
+				continue
+			}
+			if entry == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 func parseExternalTag(tagValueObj TagConfigValue, tagKey string, groupFilters map[string]interface{}) (Tag, error) {

--- a/src/common/tagging/tag_group.go
+++ b/src/common/tagging/tag_group.go
@@ -49,7 +49,7 @@ func (t *TagGroup) SetTags(tags []tags.ITag) {
 	for _, tag := range tags {
 		tag.Init()
 		tag.SetTagPrefix(t.Options.TagPrefix)
-		if !t.IsTagSkipped(tag) && (t.SpecifiedTags == nil || len(t.SpecifiedTags) == 0 || utils.InSlice(t.SpecifiedTags, strings.TrimPrefix(tag.GetKey(), t.Options.TagPrefix))) {
+		if !t.IsTagSkipped(tag) && (len(t.SpecifiedTags) == 0 || utils.InSlice(t.SpecifiedTags, strings.TrimPrefix(tag.GetKey(), t.Options.TagPrefix))) {
 			t.tags = append(t.tags, tag)
 		}
 	}


### PR DESCRIPTION
**Restrict ${env:...} expansion in --config-file to prevent env-var exfiltration**
**What**
The external tag-group config (--config-file) supported ${env:NAME} expansion of any environment variable, with the expanded value written as a tag into IaC files. Combined with the bridgecrewio/yor-action auto-commit flow, anyone who could edit the config (e.g. via a PR when the file is versioned alongside the IaC) could have Yor read a runner environment variable and persist it into the repo. This MR locks that down.

**Changes**
[src/common/tagging/external/tag_group.go](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/src/common/tagging/external/tag_group.go:1) — ${env:NAME} now only expands names matching an allowlist (YOR_* prefix, plus GIT_BRANCH for backward compatibility). A hard denylist (GITHUB_TOKEN, AWS_*, anything containing SECRET / PASSWORD / API_KEY / CREDENTIAL, …) always wins. Refused expansions leave the literal ${env:NAME} in place and log a warning.
New env vars: YOR_ENV_ALLOWLIST (comma-separated, supports PREFIX* globs) to additively allow extra names, and YOR_DISABLE_ENV_EXPANSION=1 as a global kill switch.
[src/common/tagging/external/env_expansion_test.go](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/src/common/tagging/external/env_expansion_test.go:1) — unit tests for allowlist, denylist precedence, operator extension, kill switch, missing var, passthrough.
[entrypoint.sh](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/index.html?id=15d2a252-63ce-47be-812a-8697ef33ae8b&parentId=1&origin=5a7bc161-afc7-47ae-9a8e-8f6e71f56f8f&swVersion=4&extensionId=PaloAltoNetworks.cortex-ai&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&purpose=webviewView) — refuses to auto-commit when --config-file resolves to a path inside the directory passed to -d; emits a GitHub Actions error and exits 2. Opt-out via commit_changes: 'NO' or by moving the config out.
[docs/3.Custom Taggers/Custom_tagger_YAML.md](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/docs/3.Custom%20Taggers/Custom_tagger_YAML.md:1) + [README.md](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/index.html?id=15d2a252-63ce-47be-812a-8697ef33ae8b&parentId=1&origin=5a7bc161-afc7-47ae-9a8e-8f6e71f56f8f&swVersion=4&extensionId=PaloAltoNetworks.cortex-ai&platform=electron&vscode-resource-base-authority=vscode-resource.vscode-cdn.net&parentOrigin=vscode-file%3A%2F%2Fvscode-app&purpose=webviewView) — new "Security considerations for --config-file" section and a pointer next to the CLI example.
[src/cloudformation/structure/cloudformation_parser.go](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/src/cloudformation/structure/cloudformation_parser.go:1), [src/common/tagging/tag_group.go](vscode-webview://113bofgui6flqd4mb0r7usevd9sddnldrkptj1954c3v8qtd4fig/src/common/tagging/tag_group.go:1) — unrelated one-line cleanups.
Why two layers
The Go-level allowlist protects every Yor invocation (CLI, pre-commit, third-party CI). The shell-level guard hardens the specific deployment where exploitation is amplified by an automatic push.

**Breaking changes**
${env:NAME} no longer expands arbitrary variables. Configs referencing names outside YOR_* / GIT_BRANCH will now write the literal ${env:NAME} as the tag value and log a warning. Migration: rename to a YOR_ prefix or add to YOR_ENV_ALLOWLIST. Names matching the credential denylist cannot be re-enabled — by design.
bridgecrewio/yor-action now exits 2 when --config-file lives inside the scanned directory and commit_changes is YES (default). Migration: move the config out of -d, or set commit_changes: 'NO'. Local CLI use and non-action CI are unaffected.
New environment variables consumed by Yor: YOR_ENV_ALLOWLIST, YOR_DISABLE_ENV_EXPANSION. Pre-existing variables with these names will now influence Yor's behavior.